### PR TITLE
Add `--vmaf-options` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# Unreleased (v0.1.2)
+# Unreleased (v0.2.0)
+* Add optional `--vmaf-options` argument to _vmaf, sample-encode, crf-search, auto-encode_ commands.
 * Fail fast if ffmpeg cut samples are empty (< 1K).
 * Handle input durations lower than the sample duration by using the whole input as a single sample.
 

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -52,6 +52,11 @@ pub struct Args {
 
     #[clap(skip)]
     pub quiet: bool,
+
+    /// Optional libvmaf options string. See https://ffmpeg.org/ffmpeg-filters.html#libvmaf.
+    /// E.g. "n_threads=8:n_subsample=4:log_path=./vmaf.log"
+    #[clap(long)]
+    pub vmaf_options: Option<String>,
 }
 
 pub async fn crf_search(args: Args) -> anyhow::Result<()> {
@@ -95,6 +100,7 @@ pub async fn run(
         max_crf,
         samples,
         quiet,
+        vmaf_options,
     }: &Args,
     bar: ProgressBar,
 ) -> anyhow::Result<Sample> {
@@ -107,6 +113,7 @@ pub async fn run(
         samples: *samples,
         keep: false,
         stdout_format: sample_encode::StdoutFormat::Json,
+        vmaf_options: vmaf_options.clone(),
     };
 
     bar.set_length(BAR_LEN);

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -48,6 +48,11 @@ pub struct Args {
     /// Stdout message format `human` or `json`.
     #[clap(long, arg_enum, default_value_t = StdoutFormat::Human)]
     pub stdout_format: StdoutFormat,
+
+    /// Optional libvmaf options string. See https://ffmpeg.org/ffmpeg-filters.html#libvmaf.
+    /// E.g. "n_threads=8:n_subsample=4:log_path=./vmaf.log"
+    #[clap(long)]
+    pub vmaf_options: Option<String>,
 }
 
 pub async fn sample_encode(args: Args) -> anyhow::Result<()> {
@@ -70,6 +75,7 @@ pub async fn run(
         samples,
         keep,
         stdout_format,
+        vmaf_options,
     }: Args,
     bar: ProgressBar,
 ) -> anyhow::Result<Output> {
@@ -129,7 +135,7 @@ pub async fn run(
 
         // calculate vmaf
         bar.set_message("vmaf running,");
-        let mut vmaf = vmaf::run(&sample, &encoded_sample)?;
+        let mut vmaf = vmaf::run(&sample, &encoded_sample, vmaf_options.as_deref())?;
         let mut vmaf_score = -1.0;
         while let Some(vmaf) = vmaf.next().await {
             match vmaf {

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -9,16 +9,23 @@ use tokio_stream::StreamExt;
 pub struct Args {
     /// Original video file.
     #[clap(long)]
-    original: PathBuf,
+    pub original: PathBuf,
+
     /// Re-encoded/distorted video file.
     #[clap(long)]
-    distorted: PathBuf,
+    pub distorted: PathBuf,
+
+    /// Optional libvmaf options string. See https://ffmpeg.org/ffmpeg-filters.html#libvmaf.
+    /// E.g. "n_threads=8:n_subsample=4:log_path=./vmaf.log"
+    #[clap(long)]
+    pub vmaf_options: Option<String>,
 }
 
 pub async fn vmaf(
     Args {
         original,
         distorted,
+        vmaf_options,
     }: Args,
 ) -> anyhow::Result<()> {
     let bar = ProgressBar::new(1).with_style(
@@ -34,7 +41,7 @@ pub async fn vmaf(
         bar.set_length(d.as_secs());
     }
 
-    let mut vmaf = vmaf::run(&original, &distorted)?;
+    let mut vmaf = vmaf::run(&original, &distorted, vmaf_options.as_deref())?;
     let mut vmaf_score = -1.0;
     while let Some(vmaf) = vmaf.next().await {
         match vmaf {


### PR DESCRIPTION
Add optional `--vmaf-options <OPTIONS>` argument to _vmaf, sample-encode, crf-search, auto-encode_ commands. This string is passed to ffmpeg `libvmaf='<OPTIONS>'`, see https://ffmpeg.org/ffmpeg-filters.html#libvmaf.

# Example
```text
ab-av1 vmaf ... --vmaf-options n_threads=8:n_subsample=4:log_path=./vmaf.log
```