### PR TITLE
Add svt-av1 arguments `--keyint`, `--scd`, `--svt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased (v0.2.0)
+* Add svt-av1 arguments:
+  - `--keyint FRAME-OR-DURATION` argument supporting frame integer or duration string, _e.g. `--keyint=300` or `--keyint=10s`_.
+  - `--scd` argument enabling scene change detection.
+  - `--svt ARG` for additional args, _e.g. `--svt mbr=2000 --svt film-grain=30`_.
 * Rename _vmaf_ command argument `--reference` (was `--original`).
 * Add optional `--vmaf-options` argument to _vmaf, sample-encode, crf-search, auto-encode_ commands.
 * Fail fast if ffmpeg cut samples are empty (< 1K).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "console",
  "ffprobe",
  "futures",
+ "humantime",
  "indicatif",
  "once_cell",
  "serde_json",
@@ -243,6 +244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = "1.9"
 futures = "0.3.19"
 time = { version = "0.3", features = ["parsing", "macros"] }
 serde_json = "1.0.78"
+humantime = "2.1"
 
 [profile.release]
 lto = true

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,4 @@
+pub mod args;
 pub mod auto_encode;
 pub mod crf_search;
 pub mod encode;

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -32,7 +32,7 @@ pub struct SvtEncode {
     #[clap(short, long)]
     pub input: PathBuf,
 
-    /// Encoder preset. Higher presets means faster encodes, but with a quality tradeoff.
+    /// Encoder preset (0-13). Higher presets means faster encodes, but with a quality tradeoff.
     #[clap(long)]
     pub preset: u8,
 

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -1,0 +1,153 @@
+//! Shared argument logic.
+use crate::svtav1::SvtArgs;
+use anyhow::ensure;
+use clap::Parser;
+use std::{path::PathBuf, time::Duration};
+
+/// Encoding args that apply when encoding to an output.
+#[derive(Parser, Clone)]
+pub struct EncodeToOutput {
+    /// Output file, by default the same as input with `.av1` before the extension.
+    ///
+    /// E.g. if unspecified: -i vid.mp4 --> vid.av1.mp4
+    #[clap(short, long)]
+    pub output: Option<PathBuf>,
+
+    /// Set the output ffmpeg audio codec. See https://ffmpeg.org/ffmpeg.html#Audio-Options.
+    ///
+    /// By default when the input & output file extension match 'copy' is used, otherwise
+    /// 'libopus' is used.
+    #[clap(long = "acodec")]
+    pub audio_codec: Option<String>,
+
+    /// Set the output audio quality. See https://ffmpeg.org/ffmpeg.html#Audio-Options.
+    #[clap(long = "aq")]
+    pub audio_quality: Option<String>,
+}
+
+/// Common encoding args that apply when using svt-av1.
+#[derive(Parser, Clone)]
+pub struct SvtEncode {
+    /// Input video file.
+    #[clap(short, long)]
+    pub input: PathBuf,
+
+    /// Encoder preset. Higher presets means faster encodes, but with a quality tradeoff.
+    #[clap(long)]
+    pub preset: u8,
+
+    /// Interval between keyframes. Can be specified as a number of frames, or a duration.
+    /// E.g. "300" or "10s". Longer intervals can give better compression but make seeking
+    /// more coarse. Duration will be converted to frames using the input fps.
+    #[clap(long)]
+    pub keyint: Option<KeyInterval>,
+
+    /// Enable scene change detection. Inserts keyframes at scene changes.
+    /// Useful for higher keyframe intervals.
+    #[clap(long)]
+    pub scd: bool,
+
+    /// Additional svt-av1 arg(s). E.g. --svt mbr=2000 --svt film-grain=30
+    ///
+    /// See https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/svt-av1_encoder_user_guide.md#options
+    #[clap(long = "svt", parse(try_from_str = parse_svt_arg))]
+    pub args: Vec<String>,
+}
+
+fn parse_svt_arg(arg: &str) -> anyhow::Result<String> {
+    let mut arg = arg.to_owned();
+    if !arg.starts_with('-') {
+        if arg.find('=') == Some(1) || arg.len() == 1 {
+            arg.insert(0, '-');
+        } else {
+            arg.insert_str(0, "--");
+        }
+    }
+
+    for deny in [
+        "-i",
+        "-b",
+        "--crf",
+        "--preset",
+        "--keyint",
+        "--scd",
+        "--input-depth",
+    ] {
+        ensure!(!arg.starts_with(deny), "svt arg {deny} cannot be used here");
+    }
+
+    Ok(arg)
+}
+
+impl SvtEncode {
+    pub fn to_svt_args(&self, crf: u8, fps: anyhow::Result<f64>) -> anyhow::Result<SvtArgs<'_>> {
+        let args = self
+            .args
+            .iter()
+            .flat_map(|arg| match arg.split_once('=') {
+                Some((a, b)) => vec![a, b],
+                None => vec![arg.as_str()],
+            })
+            .collect();
+
+        Ok(SvtArgs {
+            crf,
+            input: &self.input,
+            preset: self.preset,
+            keyint: match self.keyint {
+                Some(ki) => Some(ki.svt_keyint(fps)?),
+                None => None,
+            },
+            scd: match self.scd {
+                true => 1,
+                false => 0,
+            },
+            args,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum KeyInterval {
+    Frames(i32),
+    Duration(Duration),
+}
+
+impl KeyInterval {
+    pub fn svt_keyint(&self, fps: anyhow::Result<f64>) -> anyhow::Result<i32> {
+        Ok(match self {
+            Self::Frames(keyint) => *keyint,
+            Self::Duration(duration) => (duration.as_secs_f64() * fps?).round() as i32,
+        })
+    }
+}
+
+/// Parse as integer frames or a duration.
+impl std::str::FromStr for KeyInterval {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let frame_err = match s.parse::<i32>() {
+            Ok(f) => return Ok(Self::Frames(f)),
+            Err(err) => err,
+        };
+        match humantime::parse_duration(s) {
+            Ok(d) => Ok(Self::Duration(d)),
+            Err(e) => Err(anyhow::anyhow!("frames: {frame_err}, duration: {e}")),
+        }
+    }
+}
+
+#[test]
+fn frame_interval_from_str() {
+    use std::str::FromStr;
+    let from_300 = KeyInterval::from_str("300").unwrap();
+    assert_eq!(from_300, KeyInterval::Frames(300));
+}
+
+#[test]
+fn duration_interval_from_str() {
+    use std::{str::FromStr, time::Duration};
+    let from_10s = KeyInterval::from_str("10s").unwrap();
+    assert_eq!(from_10s, KeyInterval::Duration(Duration::from_secs(10)));
+}

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -19,7 +19,7 @@ pub struct Args {
     #[clap(flatten)]
     pub svt: args::SvtEncode,
 
-    /// Encoder constant rate factor. Lower means better quality.
+    /// Encoder constant rate factor (1-63). Lower means better quality.
     #[clap(long)]
     pub crf: u8,
 

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -1,9 +1,10 @@
 use crate::{
-    command::{auto_encode, PROGRESS_CHARS},
+    command::{args, PROGRESS_CHARS},
     console_ext::style,
     ffprobe,
     process::FfmpegProgress,
-    svtav1, temporary,
+    svtav1::{self},
+    temporary,
 };
 use clap::Parser;
 use console::style;
@@ -15,20 +16,15 @@ use tokio_stream::StreamExt;
 /// Simple invocation of ffmpeg & SvtAv1EncApp to encode a video.
 #[derive(Parser)]
 pub struct Args {
-    /// Input video file.
-    #[clap(short, long)]
-    pub input: PathBuf,
+    #[clap(flatten)]
+    pub svt: args::SvtEncode,
 
     /// Encoder constant rate factor. Lower means better quality.
     #[clap(long)]
     pub crf: u8,
 
-    /// Encoder preset. Higher presets means faster encodes, but with a quality tradeoff.
-    #[clap(long)]
-    pub preset: u8,
-
     #[clap(flatten)]
-    pub encode: auto_encode::EncodeArgs,
+    pub encode: args::EncodeToOutput,
 }
 
 pub async fn encode(args: Args) -> anyhow::Result<()> {
@@ -44,11 +40,10 @@ pub async fn encode(args: Args) -> anyhow::Result<()> {
 
 pub async fn run(
     Args {
-        input,
+        svt,
         crf,
-        preset,
         encode:
-            auto_encode::EncodeArgs {
+            args::EncodeToOutput {
                 output,
                 audio_codec,
                 audio_quality,
@@ -57,7 +52,7 @@ pub async fn run(
     bar: &ProgressBar,
 ) -> anyhow::Result<()> {
     let defaulting_output = output.is_none();
-    let output = output.unwrap_or_else(|| default_output_from(&input));
+    let output = output.unwrap_or_else(|| default_output_from(&svt.input));
     // output is temporary until encoding has completed successfully
     temporary::add(&output);
 
@@ -66,17 +61,15 @@ pub async fn run(
     }
     bar.set_message("encoding, ");
 
-    let probe = ffprobe::probe(&input);
-    let has_audio = probe.as_ref().map_or(true, |p| p.has_audio);
-    let duration = probe.as_ref().map(|p| p.duration);
-    if let Ok(d) = duration {
+    let probe = ffprobe::probe(&svt.input);
+    let svt_args = svt.to_svt_args(crf, probe.fps)?;
+    let has_audio = probe.has_audio;
+    if let Ok(d) = probe.duration {
         bar.set_length(d.as_secs());
     }
 
     let mut enc = svtav1::encode(
-        &input,
-        crf,
-        preset,
+        svt_args,
         &output,
         has_audio,
         audio_codec.as_deref(),
@@ -87,7 +80,7 @@ pub async fn run(
         if fps > 0.0 {
             bar.set_message(format!("{fps} fps, "));
         }
-        if duration.is_ok() {
+        if probe.duration.is_ok() {
             bar.set_position(time.as_secs());
         }
     }
@@ -98,7 +91,7 @@ pub async fn run(
 
     // print output info
     let output_size = fs::metadata(&output).await?.len();
-    let output_percent = 100.0 * output_size as f64 / fs::metadata(&input).await?.len() as f64;
+    let output_percent = 100.0 * output_size as f64 / fs::metadata(&svt.input).await?.len() as f64;
     let output_size = style(HumanBytes(output_size)).dim().bold();
     let output_percent = style!("{}%", output_percent.round()).dim().bold();
     eprintln!(

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -30,7 +30,7 @@ pub struct Args {
     #[clap(flatten)]
     pub svt: args::SvtEncode,
 
-    /// Encoder constant rate factor. Lower means better quality.
+    /// Encoder constant rate factor (1-63). Lower means better quality.
     #[clap(long)]
     pub crf: u8,
 

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -36,7 +36,7 @@ pub async fn vmaf(
     bar.enable_steady_tick(100);
     bar.set_message("vmaf running, ");
 
-    let duration = ffprobe::probe(&original).map(|p| p.duration);
+    let duration = ffprobe::probe(&original).duration;
     if let Ok(d) = duration {
         bar.set_length(d.as_secs());
     }

--- a/src/ffprobe.rs
+++ b/src/ffprobe.rs
@@ -1,30 +1,73 @@
 //! ffprobe logic
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use std::{path::Path, time::Duration};
 
 pub struct Ffprobe {
-    /// Duration of video
-    pub duration: Duration,
+    /// Duration of video.
+    pub duration: anyhow::Result<Duration>,
     /// The video has audio stream.
     pub has_audio: bool,
+    /// Video frame rate.
+    pub fps: anyhow::Result<f64>,
 }
 
-pub fn probe(input: &Path) -> anyhow::Result<Ffprobe> {
-    let probe = ffprobe::ffprobe(&input)?;
+/// Try to ffprobe the given input.
+pub fn probe(input: &Path) -> Ffprobe {
+    let probe = match ffprobe::ffprobe(&input) {
+        Ok(p) => p,
+        Err(err) => {
+            return Ffprobe {
+                duration: Err(anyhow!("ffprobe: {err}")),
+                fps: Err(anyhow!("ffprobe: {err}")),
+                has_audio: true,
+            }
+        }
+    };
 
+    let fps = read_fps(&probe);
+    let duration = read_duration(&probe);
+    let has_audio = probe
+        .streams
+        .iter()
+        .any(|s| s.codec_type.as_deref() == Some("audio"));
+
+    Ffprobe {
+        duration,
+        fps,
+        has_audio,
+    }
+}
+
+fn read_duration(probe: &ffprobe::FfProbe) -> anyhow::Result<Duration> {
     let duration_s = probe
         .format
         .duration
         .as_deref()
         .context("ffprobe missing video duration")?
-        .parse::<f32>()
+        .parse::<f64>()
         .context("invalid ffprobe video duration")?;
+    Ok(Duration::from_secs_f64(duration_s))
+}
 
-    Ok(Ffprobe {
-        duration: Duration::from_secs_f32(duration_s),
-        has_audio: probe
-            .streams
-            .iter()
-            .any(|s| s.codec_type.as_deref() == Some("audio")),
-    })
+fn read_fps(probe: &ffprobe::FfProbe) -> anyhow::Result<f64> {
+    let vstream = probe
+        .streams
+        .iter()
+        .find(|s| s.codec_type.as_deref() == Some("video"))
+        .context("no video stream found")?;
+
+    parse_frame_rate(&vstream.avg_frame_rate)
+        .or_else(|| parse_frame_rate(&vstream.r_frame_rate))
+        .context("invalid ffprobe video frame rate")
+}
+
+/// parse "x/y" strings.
+fn parse_frame_rate(rate: &str) -> Option<f64> {
+    let (x, y) = rate.split_once('/')?;
+    let x: f64 = x.parse().ok()?;
+    let y: f64 = y.parse().ok()?;
+    if x <= 0.0 || y <= 0.0 {
+        return None;
+    }
+    Some(x / y)
 }


### PR DESCRIPTION
Add svt-av1 arguments:
  - `--keyint FRAME-OR-DURATION` argument supporting frame integer or duration string, _e.g. `--keyint=300` or `--keyint=10s`_.
  - `--scd` argument enabling scene change detection.
  - `--svt ARG` for additional args, _e.g. `--svt mbr=2000 --svt film-grain=30`_.