### PR TITLE
Replace --vmaf-options with --vmaf ARG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Unreleased (v0.2.0)
-* Add svt-av1 arguments:
+* Add svt-av1 configuration:
   - `--keyint FRAME-OR-DURATION` argument supporting frame integer or duration string, _e.g. `--keyint=300` or `--keyint=10s`_.
   - `--scd` argument enabling scene change detection.
   - `--svt ARG` for additional args, _e.g. `--svt mbr=2000 --svt film-grain=30`_.
+* Add vmaf configuration `--vmaf ARG`, _e.g. `--vmaf n_threads=8 --vmaf n_subsample=4`_.
 * Rename _vmaf_ command argument `--reference` (was `--original`).
 * Use 128k bitrate as a default for libopus audio.
 * Remove `--aq`.
-* Add optional `--vmaf-options` argument to _vmaf, sample-encode, crf-search, auto-encode_ commands.
 * Fail fast if ffmpeg cut samples are empty (< 1K).
 * Handle input durations lower than the sample duration by using the whole input as a single sample.
 

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -1,8 +1,10 @@
 //! Shared argument logic.
-use crate::svtav1::SvtArgs;
-use anyhow::ensure;
+mod svt;
+
+pub use svt::*;
+
 use clap::Parser;
-use std::{path::PathBuf, time::Duration};
+use std::{path::PathBuf, sync::Arc};
 
 /// Encoding args that apply when encoding to an output.
 #[derive(Parser, Clone)]
@@ -21,129 +23,41 @@ pub struct EncodeToOutput {
     pub audio_codec: Option<String>,
 }
 
-/// Common encoding args that apply when using svt-av1.
+/// Common vmaf options.
 #[derive(Parser, Clone)]
-pub struct SvtEncode {
-    /// Input video file.
-    #[clap(short, long)]
-    pub input: PathBuf,
-
-    /// Encoder preset (0-13). Higher presets means faster encodes, but with a quality tradeoff.
-    #[clap(long)]
-    pub preset: u8,
-
-    /// Interval between keyframes. Can be specified as a number of frames, or a duration.
-    /// E.g. "300" or "10s". Longer intervals can give better compression but make seeking
-    /// more coarse. Duration will be converted to frames using the input fps.
-    #[clap(long)]
-    pub keyint: Option<KeyInterval>,
-
-    /// Enable scene change detection. Inserts keyframes at scene changes.
-    /// Useful for higher keyframe intervals.
-    #[clap(long)]
-    pub scd: bool,
-
-    /// Additional svt-av1 arg(s). E.g. --svt mbr=2000 --svt film-grain=30
+pub struct Vmaf {
+    /// Additional vmaf arg(s). E.g. --vmaf n_threads=8 --vmaf n_subsample=4
     ///
-    /// See https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/svt-av1_encoder_user_guide.md#options
-    #[clap(long = "svt", parse(try_from_str = parse_svt_arg))]
-    pub args: Vec<String>,
+    /// See https://ffmpeg.org/ffmpeg-filters.html#libvmaf.
+    #[clap(long = "vmaf", parse(try_from_str = parse_vmaf_arg))]
+    pub args: Vec<Arc<str>>,
 }
 
-fn parse_svt_arg(arg: &str) -> anyhow::Result<String> {
-    let mut arg = arg.to_owned();
-    if !arg.starts_with('-') {
-        if arg.find('=') == Some(1) || arg.len() == 1 {
-            arg.insert(0, '-');
-        } else {
-            arg.insert_str(0, "--");
+fn parse_vmaf_arg(arg: &str) -> anyhow::Result<Arc<str>> {
+    Ok(arg.to_owned().into())
+}
+
+impl Vmaf {
+    pub fn ffmpeg_lavfi(&self) -> String {
+        if self.args.is_empty() {
+            return "libvmaf".into();
         }
-    }
-
-    for deny in [
-        "-i",
-        "-b",
-        "--crf",
-        "--preset",
-        "--keyint",
-        "--scd",
-        "--input-depth",
-    ] {
-        ensure!(!arg.starts_with(deny), "svt arg {deny} cannot be used here");
-    }
-
-    Ok(arg)
-}
-
-impl SvtEncode {
-    pub fn to_svt_args(&self, crf: u8, fps: anyhow::Result<f64>) -> anyhow::Result<SvtArgs<'_>> {
-        let args = self
-            .args
-            .iter()
-            .flat_map(|arg| match arg.split_once('=') {
-                Some((a, b)) => vec![a, b],
-                None => vec![arg.as_str()],
-            })
-            .collect();
-
-        Ok(SvtArgs {
-            crf,
-            input: &self.input,
-            preset: self.preset,
-            keyint: match self.keyint {
-                Some(ki) => Some(ki.svt_keyint(fps)?),
-                None => None,
-            },
-            scd: match self.scd {
-                true => 1,
-                false => 0,
-            },
-            args,
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum KeyInterval {
-    Frames(i32),
-    Duration(Duration),
-}
-
-impl KeyInterval {
-    pub fn svt_keyint(&self, fps: anyhow::Result<f64>) -> anyhow::Result<i32> {
-        Ok(match self {
-            Self::Frames(keyint) => *keyint,
-            Self::Duration(duration) => (duration.as_secs_f64() * fps?).round() as i32,
-        })
-    }
-}
-
-/// Parse as integer frames or a duration.
-impl std::str::FromStr for KeyInterval {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> anyhow::Result<Self> {
-        let frame_err = match s.parse::<i32>() {
-            Ok(f) => return Ok(Self::Frames(f)),
-            Err(err) => err,
-        };
-        match humantime::parse_duration(s) {
-            Ok(d) => Ok(Self::Duration(d)),
-            Err(e) => Err(anyhow::anyhow!("frames: {frame_err}, duration: {e}")),
-        }
+        let mut combined = self.args.clone().join(":");
+        combined.insert_str(0, "libvmaf=");
+        combined
     }
 }
 
 #[test]
-fn frame_interval_from_str() {
-    use std::str::FromStr;
-    let from_300 = KeyInterval::from_str("300").unwrap();
-    assert_eq!(from_300, KeyInterval::Frames(300));
+fn vmaf_lavfi() {
+    let vmaf = Vmaf {
+        args: vec!["n_threads=5".into(), "n_subsample=4".into()],
+    };
+    assert_eq!(vmaf.ffmpeg_lavfi(), "libvmaf=n_threads=5:n_subsample=4");
 }
 
 #[test]
-fn duration_interval_from_str() {
-    use std::{str::FromStr, time::Duration};
-    let from_10s = KeyInterval::from_str("10s").unwrap();
-    assert_eq!(from_10s, KeyInterval::Duration(Duration::from_secs(10)));
+fn vmaf_lavfi_default() {
+    let vmaf = Vmaf { args: vec![] };
+    assert_eq!(vmaf.ffmpeg_lavfi(), "libvmaf");
 }

--- a/src/command/args/svt.rs
+++ b/src/command/args/svt.rs
@@ -1,0 +1,131 @@
+use crate::svtav1::SvtArgs;
+use anyhow::ensure;
+use clap::Parser;
+use std::{path::PathBuf, sync::Arc, time::Duration};
+
+/// Common encoding args that apply when using svt-av1.
+#[derive(Parser, Clone)]
+pub struct SvtEncode {
+    /// Input video file.
+    #[clap(short, long)]
+    pub input: PathBuf,
+
+    /// Encoder preset (0-13). Higher presets means faster encodes, but with a quality tradeoff.
+    #[clap(long)]
+    pub preset: u8,
+
+    /// Interval between keyframes. Can be specified as a number of frames, or a duration.
+    /// E.g. "300" or "10s". Longer intervals can give better compression but make seeking
+    /// more coarse. Duration will be converted to frames using the input fps.
+    #[clap(long)]
+    pub keyint: Option<KeyInterval>,
+
+    /// Enable scene change detection. Inserts keyframes at scene changes.
+    /// Useful for higher keyframe intervals.
+    #[clap(long)]
+    pub scd: bool,
+
+    /// Additional svt-av1 arg(s). E.g. --svt mbr=2000 --svt film-grain=30
+    ///
+    /// See https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/svt-av1_encoder_user_guide.md#options
+    #[clap(long = "svt", parse(try_from_str = parse_svt_arg))]
+    pub args: Vec<Arc<str>>,
+}
+
+fn parse_svt_arg(arg: &str) -> anyhow::Result<Arc<str>> {
+    let mut arg = arg.to_owned();
+    if !arg.starts_with('-') {
+        if arg.find('=') == Some(1) || arg.len() == 1 {
+            arg.insert(0, '-');
+        } else {
+            arg.insert_str(0, "--");
+        }
+    }
+
+    for deny in [
+        "-i",
+        "-b",
+        "--crf",
+        "--preset",
+        "--keyint",
+        "--scd",
+        "--input-depth",
+    ] {
+        ensure!(!arg.starts_with(deny), "svt arg {deny} cannot be used here");
+    }
+
+    Ok(arg.into())
+}
+
+impl SvtEncode {
+    pub fn to_svt_args(&self, crf: u8, fps: anyhow::Result<f64>) -> anyhow::Result<SvtArgs<'_>> {
+        let args = self
+            .args
+            .iter()
+            .flat_map(|arg| match arg.split_once('=') {
+                Some((a, b)) => vec![a, b],
+                None => vec![arg.as_ref()],
+            })
+            .collect();
+
+        Ok(SvtArgs {
+            crf,
+            input: &self.input,
+            preset: self.preset,
+            keyint: match self.keyint {
+                Some(ki) => Some(ki.svt_keyint(fps)?),
+                None => None,
+            },
+            scd: match self.scd {
+                true => 1,
+                false => 0,
+            },
+            args,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum KeyInterval {
+    Frames(i32),
+    Duration(Duration),
+}
+
+impl KeyInterval {
+    pub fn svt_keyint(&self, fps: anyhow::Result<f64>) -> anyhow::Result<i32> {
+        Ok(match self {
+            Self::Frames(keyint) => *keyint,
+            Self::Duration(duration) => (duration.as_secs_f64() * fps?).round() as i32,
+        })
+    }
+}
+
+/// Parse as integer frames or a duration.
+impl std::str::FromStr for KeyInterval {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let frame_err = match s.parse::<i32>() {
+            Ok(f) => return Ok(Self::Frames(f)),
+            Err(err) => err,
+        };
+        match humantime::parse_duration(s) {
+            Ok(d) => Ok(Self::Duration(d)),
+            Err(e) => Err(anyhow::anyhow!("frames: {frame_err}, duration: {e}")),
+        }
+    }
+}
+
+#[test]
+fn frame_interval_from_str() {
+    use std::str::FromStr;
+    let from_300 = KeyInterval::from_str("300").unwrap();
+    assert_eq!(from_300, KeyInterval::Frames(300));
+}
+
+#[test]
+fn duration_interval_from_str() {
+    use std::{str::FromStr, time::Duration};
+    let from_10s = KeyInterval::from_str("10s").unwrap();
+    assert_eq!(from_10s, KeyInterval::Duration(Duration::from_secs(10)));
+}

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -48,10 +48,8 @@ pub struct Args {
     #[clap(skip)]
     pub quiet: bool,
 
-    /// Optional libvmaf options string. See https://ffmpeg.org/ffmpeg-filters.html#libvmaf.
-    /// E.g. "n_threads=8:n_subsample=4:log_path=./vmaf.log"
-    #[clap(long)]
-    pub vmaf_options: Option<String>,
+    #[clap(flatten)]
+    pub vmaf: args::Vmaf,
 }
 
 pub async fn crf_search(args: Args) -> anyhow::Result<()> {
@@ -94,7 +92,7 @@ pub async fn run(
         max_crf,
         samples,
         quiet,
-        vmaf_options,
+        vmaf,
     }: &Args,
     bar: ProgressBar,
 ) -> anyhow::Result<Sample> {
@@ -106,7 +104,7 @@ pub async fn run(
         samples: *samples,
         keep: false,
         stdout_format: sample_encode::StdoutFormat::Json,
-        vmaf_options: vmaf_options.clone(),
+        vmaf: vmaf.clone(),
     };
 
     bar.set_length(BAR_LEN);

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -47,10 +47,8 @@ pub struct Args {
     #[clap(long, arg_enum, default_value_t = StdoutFormat::Human)]
     pub stdout_format: StdoutFormat,
 
-    /// Optional libvmaf options string. See https://ffmpeg.org/ffmpeg-filters.html#libvmaf.
-    /// E.g. "n_threads=8:n_subsample=4:log_path=./vmaf.log"
-    #[clap(long)]
-    pub vmaf_options: Option<String>,
+    #[clap(flatten)]
+    pub vmaf: args::Vmaf,
 }
 
 pub async fn sample_encode(args: Args) -> anyhow::Result<()> {
@@ -72,7 +70,7 @@ pub async fn run(
         samples,
         keep,
         stdout_format,
-        vmaf_options,
+        vmaf,
     }: Args,
     bar: ProgressBar,
 ) -> anyhow::Result<Output> {
@@ -139,7 +137,7 @@ pub async fn run(
 
         // calculate vmaf
         bar.set_message("vmaf running,");
-        let mut vmaf = vmaf::run(&sample, &encoded_sample, vmaf_options.as_deref())?;
+        let mut vmaf = vmaf::run(&sample, &encoded_sample, &vmaf.ffmpeg_lavfi())?;
         let mut vmaf_score = -1.0;
         while let Some(vmaf) = vmaf.next().await {
             match vmaf {

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -3,7 +3,7 @@ use crate::{
     process::{exit_ok, CommandExt, FfmpegProgress},
     yuv,
 };
-use anyhow::{ensure, Context};
+use anyhow::Context;
 use std::path::Path;
 use tokio::process::Command;
 use tokio_process_stream::{Item, ProcessChunkStream};
@@ -14,27 +14,16 @@ use tokio_stream::{Stream, StreamExt};
 pub fn run(
     reference: &Path,
     distorted: &Path,
-    options: Option<&str>,
+    lavfi: &str,
 ) -> anyhow::Result<impl Stream<Item = VmafOut>> {
     let (yuv_out, yuv_pipe) = yuv::pipe420p10le(reference)?;
     let yuv_pipe = yuv_pipe.filter_map(VmafOut::ignore_ok);
-
-    let libvmaf_options = match options {
-        None => "libvmaf".into(),
-        Some(opts) => {
-            ensure!(
-                !opts.contains('\''),
-                "invalid vmaf-options: must not contain `'` character"
-            );
-            format!("libvmaf='{opts}'")
-        }
-    };
 
     let vmaf: ProcessChunkStream = Command::new("ffmpeg")
         .kill_on_drop(true)
         .arg2("-i", distorted)
         .arg2("-i", "-")
-        .arg2("-lavfi", &libvmaf_options)
+        .arg2("-lavfi", lavfi)
         .arg2("-f", "null")
         .arg("-")
         .stdin(yuv_out)


### PR DESCRIPTION
* Add vmaf configuration `--vmaf ARG`, _e.g. `--vmaf n_threads=8 --vmaf n_subsample=4`_.

This is more consistent with the `--svt ARG` for svt-av1 options. Plus should be more flexible if we want to move to directly invoking vmaf instead of using ffmpeg later.