### PR TITLE
Default vmaf n_threads to the number of CPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - `--scd` argument enabling scene change detection.
   - `--svt ARG` for additional args, _e.g. `--svt mbr=2000 --svt film-grain=30`_.
 * Add vmaf configuration `--vmaf ARG`, _e.g. `--vmaf n_threads=8 --vmaf n_subsample=4`_.
+* Set vmaf n_threads to the number of logical CPUs by default.
 * Rename _vmaf_ command argument `--reference` (was `--original`).
 * Use 128k bitrate as a default for libopus audio.
 * Remove `--aq`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "futures",
  "humantime",
  "indicatif",
+ "num_cpus",
  "once_cell",
  "serde_json",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3.19"
 time = { version = "0.3", features = ["parsing", "macros"] }
 serde_json = "1.0.78"
 humantime = "2.1"
+num_cpus = "1.13.1"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Explicitly set vmaf n_threads to all logical cores unless it is provided manually in a `--vmaf` arg.

This should address #9 issue with the upstream default not using call cores.