### PR TITLE
Add `--vfilter` & vmaf `--reference-vfilter`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
-    - run: rustup update stable
     - uses: actions/checkout@v2
     - run: cargo test
     # check print-completions don't fail
@@ -25,13 +24,11 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
-    - run: rustup update stable
     - uses: actions/checkout@v2
     - run: cargo check
 
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-    - run: rustup update stable
     - uses: actions/checkout@v2
     - run: cargo fmt -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
   - `--scd true|false` argument enabling scene change detection.
     Default scd on when using default keyint & input duration is over 3m.
   - `--svt ARG` for additional args, _e.g. `--svt mbr=2000 --svt film-grain=30`_.
-* Add vmaf configuration `--vmaf ARG`, _e.g. `--vmaf n_threads=8 --vmaf n_subsample=4`_.
+* Add `--vfilter` argument to apply a ffmpeg video filter (crop, scale etc) to the input before av1 encoding.
 * Add `--pix-format ARG` argument supporting `yuv420p10le` (default) & `yuv420p`.
-* Support multiple audio & subtitle streams.
-* Default vmaf n_threads to the number of logical CPUs.
+* Add vmaf configuration `--vmaf ARG`, _e.g. `--vmaf n_threads=8 --vmaf n_subsample=4`_.
 * Rename _vmaf_ command argument `--reference` (was `--original`).
+* Add _vmaf_ command `--reference-vfilter` argument, similar to `--vfilter`.
+* Default vmaf n_threads to the number of logical CPUs.
 * Linux: _vmaf_ use fifo to convert both reference & distorted to yuv which fixes vmaf accuracy in some cases.
+* Support multiple audio & subtitle streams.
 * Use 128k bitrate as a default for libopus audio.
 * Remove `--aq`.
 * Fail fast if ffmpeg cut samples are empty (< 1K).

--- a/src/command/args/svt.rs
+++ b/src/command/args/svt.rs
@@ -125,7 +125,7 @@ impl SvtEncode {
     pub fn encode_hint(&self, crf: u8) -> String {
         let Self {
             input,
-            vfilter: video_filter,
+            vfilter,
             preset,
             pix_format,
             keyint,
@@ -143,7 +143,7 @@ impl SvtEncode {
         if *pix_format != PixelFormat::Yuv420p10le {
             write!(hint, " --pix-format {pix_format}").unwrap();
         }
-        if let Some(filter) = video_filter {
+        if let Some(filter) = vfilter {
             write!(hint, " --vfilter {filter:?}").unwrap();
         }
         for arg in args {
@@ -283,7 +283,7 @@ fn to_svt_args_default_over_3m() {
 
     let SvtArgs {
         input,
-        vfilter: video_filter,
+        vfilter,
         pix_fmt,
         crf,
         preset,
@@ -293,7 +293,7 @@ fn to_svt_args_default_over_3m() {
     } = svt.to_svt_args(32, &probe).expect("to_svt_args");
 
     assert_eq!(input, svt.input);
-    assert_eq!(video_filter, Some("scale=320:-1,fps=film"));
+    assert_eq!(vfilter, Some("scale=320:-1,fps=film"));
     assert_eq!(crf, 32);
     assert_eq!(preset, svt.preset);
     assert_eq!(pix_fmt, svt.pix_format);
@@ -322,7 +322,7 @@ fn to_svt_args_default_under_3m() {
 
     let SvtArgs {
         input,
-        vfilter: video_filter,
+        vfilter,
         pix_fmt,
         crf,
         preset,
@@ -332,7 +332,7 @@ fn to_svt_args_default_under_3m() {
     } = svt.to_svt_args(32, &probe).expect("to_svt_args");
 
     assert_eq!(input, svt.input);
-    assert_eq!(video_filter, None);
+    assert_eq!(vfilter, None);
     assert_eq!(crf, 32);
     assert_eq!(preset, svt.preset);
     assert_eq!(pix_fmt, svt.pix_format);

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -139,6 +139,7 @@ pub async fn run(
         bar.set_message("vmaf running,");
         let mut vmaf = vmaf::run(
             &sample,
+            svt.vfilter.as_deref(),
             &encoded_sample,
             &vmaf.ffmpeg_lavfi(),
             svt.pix_format,

--- a/src/ffprobe.rs
+++ b/src/ffprobe.rs
@@ -61,15 +61,20 @@ fn read_fps(probe: &ffprobe::FfProbe) -> anyhow::Result<f64> {
         .context("invalid ffprobe video frame rate")
 }
 
-/// parse "x/y" strings.
-fn parse_frame_rate(rate: &str) -> Option<f64> {
-    let (x, y) = rate.split_once('/')?;
-    let x: f64 = x.parse().ok()?;
-    let y: f64 = y.parse().ok()?;
-    if x <= 0.0 || y <= 0.0 {
-        return None;
+/// parse "x/y" or float strings.
+pub fn parse_frame_rate(rate: &str) -> Option<f64> {
+    if let Some((x, y)) = rate.split_once('/') {
+        let x: f64 = x.parse().ok()?;
+        let y: f64 = y.parse().ok()?;
+        if x <= 0.0 || y <= 0.0 {
+            return None;
+        }
+        Some(x / y)
+    } else {
+        rate.parse()
+            .ok()
+            .filter(|f: &f64| f.is_finite() && *f > 0.0)
     }
-    Some(x / y)
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -14,11 +14,12 @@ use tokio_stream::{Stream, StreamExt};
 /// This can produce more accurate results than testing directly from original source.
 pub fn run(
     reference: &Path,
+    reference_video_filter: Option<&str>,
     distorted: &Path,
     lavfi: &str,
     pix_fmt: PixelFormat,
 ) -> anyhow::Result<impl Stream<Item = VmafOut>> {
-    let (yuv_out, yuv_pipe) = yuv::pipe(reference, pix_fmt)?;
+    let (yuv_out, yuv_pipe) = yuv::pipe(reference, pix_fmt, reference_video_filter)?;
     let yuv_pipe = yuv_pipe.filter_map(VmafOut::ignore_ok);
 
     // If possible convert distorted to yuv, in some cases this fixes inaccuracy

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -14,12 +14,12 @@ use tokio_stream::{Stream, StreamExt};
 /// This can produce more accurate results than testing directly from original source.
 pub fn run(
     reference: &Path,
-    reference_video_filter: Option<&str>,
+    reference_vfilter: Option<&str>,
     distorted: &Path,
     lavfi: &str,
     pix_fmt: PixelFormat,
 ) -> anyhow::Result<impl Stream<Item = VmafOut>> {
-    let (yuv_out, yuv_pipe) = yuv::pipe(reference, pix_fmt, reference_video_filter)?;
+    let (yuv_out, yuv_pipe) = yuv::pipe(reference, pix_fmt, reference_vfilter)?;
     let yuv_pipe = yuv_pipe.filter_map(VmafOut::ignore_ok);
 
     // If possible convert distorted to yuv, in some cases this fixes inaccuracy

--- a/src/yuv.rs
+++ b/src/yuv.rs
@@ -11,11 +11,13 @@ use tokio_stream::Stream;
 pub fn pipe(
     input: &Path,
     pix_fmt: PixelFormat,
+    vfilter: Option<&str>,
 ) -> anyhow::Result<(Stdio, impl Stream<Item = anyhow::Result<FfmpegProgress>>)> {
     let mut yuv4mpegpipe = Command::new("ffmpeg")
         .kill_on_drop(true)
         .arg2("-i", input)
         .arg2("-pix_fmt", pix_fmt.as_str())
+        .arg2_opt("-vf", vfilter)
         .arg2("-strict", "-1")
         .arg2("-f", "yuv4mpegpipe")
         .arg("-")


### PR DESCRIPTION
* Add `--vfilter` argument to apply a ffmpeg video filter (crop, scale etc) to the input before av1 encoding.
* Add _vmaf_ command `--reference-vfilter` argument, similar to `--vfilter`.

Resolves #10 