### PR TITLE
Add --temp-dir argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Rename _vmaf_ command argument `--reference` (was `--original`).
 * Add _vmaf_ command `--reference-vfilter` argument, similar to `--vfilter`.
 * Default vmaf n_threads to the number of logical CPUs.
+* Add `--temp-dir` argument to specify storage of sample data.
+* Create samples concurrently while encoding to reduce io lags waiting to encode.
+* _crf-search_ re-use samples for crf analysis.
 * Linux: _vmaf_ use fifo to convert both reference & distorted to yuv which fixes vmaf accuracy in some cases.
 * Support multiple audio & subtitle streams.
 * Use 128k bitrate as a default for libopus audio.

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -6,6 +6,20 @@ pub use svt::*;
 use clap::Parser;
 use std::{path::PathBuf, sync::Arc};
 
+/// Sampling arguments.
+#[derive(Parser, Clone)]
+pub struct Sample {
+    /// Number of 20s samples to use across the input video.
+    /// More samples take longer but may provide a more accurate result.
+    #[clap(long, default_value_t = 3)]
+    pub samples: u64,
+
+    /// Directory to store temporary sample data in.
+    /// Defaults to using the input's directory.
+    #[clap(long)]
+    pub temp_dir: Option<PathBuf>,
+}
+
 /// Encoding args that apply when encoding to an output.
 #[derive(Parser, Clone)]
 pub struct EncodeToOutput {

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -5,6 +5,7 @@ use crate::{
         PROGRESS_CHARS,
     },
     console_ext::style,
+    temporary,
 };
 use clap::Parser;
 use console::style;
@@ -45,12 +46,12 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
     }
 
     let best = crf_search::run(&search, bar.clone()).await?;
-
     bar.finish_with_message(format!(
         "crf {}, VMAF {:.2}, ",
         style(best.crf).green(),
         style(best.enc.vmaf).green()
     ));
+    temporary::clean_all().await;
 
     let bar = ProgressBar::new(12).with_style(
         ProgressStyle::default_bar()

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -4,7 +4,7 @@ use crate::{
     ffprobe,
     process::FfmpegProgress,
     svtav1::{self},
-    temporary,
+    temporary::{self, TempKind},
 };
 use clap::Parser;
 use console::style;
@@ -52,7 +52,7 @@ pub async fn run(
     let defaulting_output = output.is_none();
     let output = output.unwrap_or_else(|| default_output_from(&svt.input));
     // output is temporary until encoding has completed successfully
-    temporary::add(&output);
+    temporary::add(&output, TempKind::NotKeepable);
 
     if defaulting_output {
         bar.println(style!("Encoding {output:?}").dim().to_string());

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,7 +1,8 @@
 //! ffmpeg logic
 use crate::{
     process::{ensure_success, CommandExt},
-    temporary, SAMPLE_SIZE_S,
+    temporary::{self, TempKind},
+    SAMPLE_SIZE_S,
 };
 use anyhow::Context;
 use std::{
@@ -13,17 +14,27 @@ use tokio::process::Command;
 /// Create a 20s sample from `sample_start`.
 ///
 /// Fast as this uses `-c:v copy`.
-pub async fn copy(input: &Path, sample_start: Duration) -> anyhow::Result<PathBuf> {
+pub async fn copy(
+    input: &Path,
+    sample_start: Duration,
+    temp_dir: Option<PathBuf>,
+) -> anyhow::Result<PathBuf> {
     let ext = input
         .extension()
         .and_then(|e| e.to_str())
         .context("input has no extension")?;
-    let dest = input.with_extension(format!(
+    let mut dest = input.with_extension(format!(
         "sample{}+{SAMPLE_SIZE_S}.{ext}",
         sample_start.as_secs()
     ));
-
-    temporary::add(&dest);
+    if let (Some(mut temp), Some(name)) = (temp_dir, dest.file_name()) {
+        temp.push(name);
+        dest = temp;
+    }
+    if dest.exists() {
+        return Ok(dest);
+    }
+    temporary::add(&dest, TempKind::Keepable);
 
     let out = Command::new("ffmpeg")
         .arg("-y")

--- a/src/temporary.rs
+++ b/src/temporary.rs
@@ -1,27 +1,59 @@
 //! temp file logic
 use once_cell::sync::Lazy;
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::Mutex,
 };
 
-static TEMPS: Lazy<Mutex<HashSet<PathBuf>>> = Lazy::new(<_>::default);
+static TEMPS: Lazy<Mutex<HashMap<PathBuf, TempKind>>> = Lazy::new(<_>::default);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TempKind {
+    /// Should always be deleted at the end of the program.
+    NotKeepable,
+    /// Usually deleted but may be kept, e.g. with --keep.
+    Keepable,
+}
 
 /// Add a file as temporary so it can be deleted later.
-pub fn add(file: impl Into<PathBuf>) {
-    TEMPS.lock().unwrap().insert(file.into());
+pub fn add(file: impl Into<PathBuf>, kind: TempKind) {
+    TEMPS.lock().unwrap().insert(file.into(), kind);
 }
 
 /// Remove a previously added file so that it won't be deleted later,
 /// if it hasn't already.
 pub fn unadd(file: &Path) -> bool {
-    TEMPS.lock().unwrap().remove(file)
+    TEMPS.lock().unwrap().remove(file).is_some()
 }
 
 /// Delete all added temporary files.
-pub async fn clean() {
-    for file in std::mem::take(&mut *TEMPS.lock().unwrap()) {
+/// If `keep_keepables` true don't delete [`TempKind::Keepable`] temporary files.
+pub async fn clean(keep_keepables: bool) {
+    match keep_keepables {
+        true => clean_non_keepables().await,
+        false => clean_all().await,
+    }
+}
+
+/// Delete all added temporary files.
+pub async fn clean_all() {
+    for (file, _) in std::mem::take(&mut *TEMPS.lock().unwrap()) {
         let _ = tokio::fs::remove_file(file).await;
+    }
+}
+
+async fn clean_non_keepables() {
+    let matching: Vec<_> = TEMPS
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|(_, k)| **k == TempKind::NotKeepable)
+        .map(|(f, _)| f.clone())
+        .collect();
+
+    for file in matching {
+        let _ = tokio::fs::remove_file(&file).await;
+        TEMPS.lock().unwrap().remove(&file);
     }
 }

--- a/src/yuv.rs
+++ b/src/yuv.rs
@@ -33,6 +33,7 @@ pub fn pipe(
 #[cfg(unix)]
 pub mod unix {
     use super::*;
+    use crate::temporary::{self, TempKind};
     use rand::{
         distributions::{Alphanumeric, DistString},
         thread_rng,
@@ -49,7 +50,7 @@ pub mod unix {
             Alphanumeric.sample_string(&mut thread_rng(), 12)
         ));
         unix_named_pipe::create(&fifo, None)?;
-        crate::temporary::add(&fifo);
+        temporary::add(&fifo, TempKind::NotKeepable);
 
         let yuv4mpegpipe = Command::new("ffmpeg")
             .kill_on_drop(true)


### PR DESCRIPTION
Create samples concurrently with encoding to prevent slow io stalls
crf-search re-use samples for all crfs

Resolves #6 