### PR TITLE
Add `--downmix-to-stereo` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased (v0.2.1)
+* Add `--downmix-to-stereo` option, if enabled & the input streams use > 3 channels (dts 5.1 etc), 
+  downmix input audio streams to stereo.
+
 # v0.2.0
 * Add svt-av1 option `--keyint FRAME-OR-DURATION` argument supporting frame integer or duration string. 
   _E.g. `--keyint=300` or `--keyint=10s`_.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,9 +27,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "7a99269dff3bc004caa411f38845c20303f1e393ca2bd6581576fa3a7f59577d"
 
 [[package]]
 name = "atty"

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -17,12 +17,20 @@ pub struct EncodeToOutput {
     #[clap(short, long)]
     pub output: Option<PathBuf>,
 
-    /// Set the output ffmpeg audio codec. See https://ffmpeg.org/ffmpeg.html#Audio-Options.
+    /// Set the output ffmpeg audio codec.
+    /// By default when the input & output file extension match 'copy' is used,
+    /// otherwise 'libopus'.
     ///
-    /// By default when the input & output file extension match 'copy' is used, otherwise
-    /// libopus is used.
+    /// See https://ffmpeg.org/ffmpeg.html#Audio-Options.
     #[clap(long = "acodec")]
     pub audio_codec: Option<String>,
+
+    /// Downmix input audio streams to stereo if input streams use greater than
+    /// 3 channels.
+    ///
+    /// No effect if the input audio has 3 or fewer channels.
+    #[clap(long)]
+    pub downmix_to_stereo: bool,
 }
 
 /// Sampling arguments.

--- a/src/command/args/svt.rs
+++ b/src/command/args/svt.rs
@@ -278,6 +278,7 @@ fn to_svt_args_default_over_3m() {
     let probe = Ffprobe {
         duration: Ok(Duration::from_secs(300)),
         has_audio: true,
+        max_audio_channels: None,
         fps: Ok(30.0),
     };
 
@@ -317,6 +318,7 @@ fn to_svt_args_default_under_3m() {
     let probe = Ffprobe {
         duration: Ok(Duration::from_secs(179)),
         has_audio: true,
+        max_audio_channels: None,
         fps: Ok(24.0),
     };
 


### PR DESCRIPTION
* Add `--downmix-to-stereo` option, if enabled & the input streams use > 3 channels (dts 5.1 etc), downmix input audio streams to stereo.