### PR TITLE
Don't use avi, y4m, ivf extensions in default output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Add `--downmix-to-stereo` option, if enabled & the input streams use > 3 channels (dts 5.1 etc), 
   downmix input audio streams to stereo.
 * After encoding print per-stream sizes in addition to the file size & percent.
+* When defaulting the output file don't use input extension if it is _avi, y4m, ivf_, use mp4 instead.
 
 # v0.2.0
 * Add svt-av1 option `--keyint FRAME-OR-DURATION` argument supporting frame integer or duration string. 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d76c22c9b9b215eeb8d016ad3a90417bd13cb24cf8142756e6472445876cab7"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -132,7 +132,12 @@ pub async fn run(
 
 /// * input: vid.ext -> output: vid.av1.ext
 pub fn default_output_from(input: &Path) -> PathBuf {
-    match input.extension().and_then(|e| e.to_str()) {
+    match input
+        .extension()
+        .and_then(|e| e.to_str())
+        // don't use extensions that won't work
+        .filter(|e| *e != "avi" && *e != "y4m" && *e != "ivf")
+    {
         Some(ext) => input.with_extension(format!("av1.{ext}")),
         _ => input.with_extension("av1.mp4"),
     }


### PR DESCRIPTION
When defaulting the output file don't use input extension if it is _avi, y4m, ivf_, use mp4 instead.