### PR TITLE
Vmaf upscale lower resolutions to 1080p + add `--vmaf-width` option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
+    - run: rustup update stable
     - uses: actions/checkout@v2
     - run: cargo test --locked
     # check print-completions don't fail
@@ -24,11 +25,13 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
+    - run: rustup update stable
     - uses: actions/checkout@v2
     - run: cargo check
 
   rustfmt:
     runs-on: ubuntu-latest
     steps:
+    - run: rustup update stable
     - uses: actions/checkout@v2
     - run: cargo fmt -- --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /aur
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
   downmix input audio streams to stereo.
 * After encoding print per-stream sizes in addition to the file size & percent.
 * When defaulting the output file don't use input extension if it is _avi, y4m, ivf_, use mp4 instead.
+* Improve VMAF accuracy for lower than 1080p resolutions by bicubic upscaling the streams to 1080p
+  for the VMAF calculation. This will result in lower scores than were previously reported for such videos.
 
 # v0.2.0
 * Add svt-av1 option `--keyint FRAME-OR-DURATION` argument supporting frame integer or duration string. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased (v0.2.1)
+# Unreleased (v0.3.0)
 * Add `--downmix-to-stereo` option, if enabled & the input streams use > 3 channels (dts 5.1 etc), 
   downmix input audio streams to stereo.
 * After encoding print per-stream sizes in addition to the file size & percent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
   downmix input audio streams to stereo.
 * After encoding print per-stream sizes in addition to the file size & percent.
 * When defaulting the output file don't use input extension if it is _avi, y4m, ivf_, use mp4 instead.
-* Improve VMAF accuracy for lower than 1080p resolutions by bicubic upscaling the streams to 1080p
-  for the VMAF calculation. This will result in lower scores than were previously reported for such videos.
+* Add `--vmaf-width` option which sets the video resolution width to use in VMAF analysis.
+* When using the default VMAF model, improve VMAF accuracy for sub-1k resolutions by defaulting
+  `--vmaf-width=1920` whenever video resolution width is less than 1728. This will result in lower 
+  VMAF scores than were reported for such videos in previous versions.
 
 # v0.2.0
 * Add svt-av1 option `--keyint FRAME-OR-DURATION` argument supporting frame integer or duration string. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * When using the default VMAF model, improve VMAF accuracy for sub-1k resolutions by defaulting
   `--vmaf-width=1920` whenever video resolution width is less than 1728. This will result in lower 
   VMAF scores than were reported for such videos in previous versions.
+* Strip debug symbols in release builds by default which reduces binary size _(requires rustc 1.59)_.
 
 # v0.2.0
 * Add svt-av1 option `--keyint FRAME-OR-DURATION` argument supporting frame integer or duration string. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ rand = "0.8.5"
 [profile.release]
 lto = true
 opt-level = "s"
+strip = true

--- a/README.md
+++ b/README.md
@@ -77,3 +77,6 @@ cargo install --git https://github.com/alexheretic/ab-av1
 * opus
 
 `ffmpeg`, `SvtAv1EncApp` commands should be in `$PATH`.
+
+## Minimum supported rust compiler
+Maintained with [latest stable rust](https://gist.github.com/alexheretic/d1e98d8433b602e57f5d0a9637927e0c).

--- a/deploy
+++ b/deploy
@@ -8,6 +8,5 @@ cargo fmt -- --check
 cargo build --release
 
 cp "${CARGO_TARGET_DIR:-./target}/release/ab-av1" ~/bin/ab-av1
-strip ~/bin/ab-av1
 
 ls -lh ~/bin/ab-av1

--- a/src/command/args/svt.rs
+++ b/src/command/args/svt.rs
@@ -280,6 +280,7 @@ fn to_svt_args_default_over_3m() {
         has_audio: true,
         max_audio_channels: None,
         fps: Ok(30.0),
+        width: Some(720),
     };
 
     let SvtArgs {
@@ -320,6 +321,7 @@ fn to_svt_args_default_under_3m() {
         has_audio: true,
         max_audio_channels: None,
         fps: Ok(24.0),
+        width: Some(720),
     };
 
     let SvtArgs {

--- a/src/command/args/vmaf.rs
+++ b/src/command/args/vmaf.rs
@@ -9,6 +9,18 @@ pub struct Vmaf {
     /// See https://ffmpeg.org/ffmpeg-filters.html#libvmaf.
     #[clap(long = "vmaf", parse(from_str = parse_vmaf_arg))]
     pub vmaf_args: Vec<Arc<str>>,
+
+    /// Video resolution width to use in VMAF analysis. If set, video streams will be bicupic
+    /// scaled to this width during VMAF analysis. By default automatically set based on the
+    /// model and input video resolution. Setting to `0` disables any such scaling.
+    ///
+    /// Default automatic behaviour:
+    /// * Video width <  1728 => scale to 1920 (1080p)
+    /// * Video width >= 1728 => no scaling
+    ///
+    /// Scaling happens after any input/reference vfilters.
+    #[clap(long)]
+    pub vmaf_width: Option<u32>,
 }
 
 fn parse_vmaf_arg(arg: &str) -> Arc<str> {
@@ -26,15 +38,20 @@ impl Vmaf {
         let mut lavfi = args.join(":");
         lavfi.insert_str(0, "libvmaf=");
 
-        let scale_1080p = !args.iter().any(|a| a.contains("model"))
-            && distorted_width.map_or(false, |w| w < 1728);
+        let vmaf_w = match (self.vmaf_width, distorted_width) {
+            (None, Some(w)) => match VmafModel::from_args(&args) {
+                // upscale small resolutions to 1k for use with the 1k model
+                VmafModel::Vmaf1K if w < 1728 => Some(1920),
+                _ => None,
+            },
+            (w, _) => w.filter(|w| *w != 0 && Some(*w) != distorted_width),
+        };
 
-        if scale_1080p {
-            // upscale both streams to 1080p, as this resolution is what the default
-            // vmaf model is designed to work with
+        if let Some(w) = vmaf_w {
+            // scale both streams to the vmaf width
             lavfi.insert_str(
                 0,
-                "[0:v]scale=1920:-1:flags=bicubic[dis];[1:v]scale=1920:-1:flags=bicubic[ref];[dis][ref]",
+                &format!("[0:v]scale={w}:-1:flags=bicubic[dis];[1:v]scale={w}:-1:flags=bicubic[ref];[dis][ref]"),
             );
         }
 
@@ -42,17 +59,42 @@ impl Vmaf {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum VmafModel {
+    /// Default 1080p model.
+    Vmaf1K,
+    /// Some other user specified model.
+    Custom,
+}
+
+impl VmafModel {
+    fn from_args(args: &[Arc<str>]) -> Self {
+        let using_custom_model = args
+            .iter()
+            .filter(|v| !v.ends_with("version=vmaf_v0.6.1"))
+            .any(|v| v.contains("model"));
+        match using_custom_model {
+            true => Self::Custom,
+            false => Self::Vmaf1K,
+        }
+    }
+}
+
 #[test]
 fn vmaf_lavfi() {
     let vmaf = Vmaf {
         vmaf_args: vec!["n_threads=5".into(), "n_subsample=4".into()],
+        vmaf_width: None,
     };
     assert_eq!(vmaf.ffmpeg_lavfi(None), "libvmaf=n_threads=5:n_subsample=4");
 }
 
 #[test]
 fn vmaf_lavfi_default() {
-    let vmaf = Vmaf { vmaf_args: vec![] };
+    let vmaf = Vmaf {
+        vmaf_args: vec![],
+        vmaf_width: None,
+    };
     let expected = format!("libvmaf=n_threads={}", num_cpus::get());
     assert_eq!(vmaf.ffmpeg_lavfi(None), expected);
 }
@@ -61,6 +103,7 @@ fn vmaf_lavfi_default() {
 fn vmaf_lavfi_include_n_threads() {
     let vmaf = Vmaf {
         vmaf_args: vec!["log_path=output.xml".into()],
+        vmaf_width: None,
     };
     let expected = format!("libvmaf=log_path=output.xml:n_threads={}", num_cpus::get());
     assert_eq!(vmaf.ffmpeg_lavfi(None), expected);
@@ -71,6 +114,7 @@ fn vmaf_lavfi_include_n_threads() {
 fn vmaf_lavfi_small_width() {
     let vmaf = Vmaf {
         vmaf_args: vec!["n_threads=5".into(), "n_subsample=4".into()],
+        vmaf_width: None,
     };
     assert_eq!(
         vmaf.ffmpeg_lavfi(Some(1280)),
@@ -80,7 +124,7 @@ fn vmaf_lavfi_small_width() {
     );
 }
 
-/// If user has overriden the model, don't presume to scale
+/// If user has overriden the model, don't default a vmaf width
 #[test]
 fn vmaf_lavfi_small_width_custom_model() {
     let vmaf = Vmaf {
@@ -89,6 +133,7 @@ fn vmaf_lavfi_small_width_custom_model() {
             "n_threads=5".into(),
             "n_subsample=4".into(),
         ],
+        vmaf_width: None,
     };
     assert_eq!(
         vmaf.ffmpeg_lavfi(Some(1280)),
@@ -97,9 +142,29 @@ fn vmaf_lavfi_small_width_custom_model() {
 }
 
 #[test]
+fn vmaf_lavfi_custom_model_and_width() {
+    let vmaf = Vmaf {
+        vmaf_args: vec![
+            "model=version=foo".into(),
+            "n_threads=5".into(),
+            "n_subsample=4".into(),
+        ],
+        // if specified just do it
+        vmaf_width: Some(123),
+    };
+    assert_eq!(
+        vmaf.ffmpeg_lavfi(Some(1280)),
+        "[0:v]scale=123:-1:flags=bicubic[dis];\
+        [1:v]scale=123:-1:flags=bicubic[ref];\
+        [dis][ref]libvmaf=model=version=foo:n_threads=5:n_subsample=4"
+    );
+}
+
+#[test]
 fn vmaf_lavfi_1080p() {
     let vmaf = Vmaf {
         vmaf_args: vec!["n_threads=5".into(), "n_subsample=4".into()],
+        vmaf_width: None,
     };
     assert_eq!(
         vmaf.ffmpeg_lavfi(Some(1920)),

--- a/src/command/args/vmaf.rs
+++ b/src/command/args/vmaf.rs
@@ -16,15 +16,29 @@ fn parse_vmaf_arg(arg: &str) -> Arc<str> {
 }
 
 impl Vmaf {
-    pub fn ffmpeg_lavfi(&self) -> String {
+    /// Returns ffmpeg `filter_complex`/`lavfi` value for calculating vmaf.
+    pub fn ffmpeg_lavfi(&self, distorted_width: Option<u32>) -> String {
         let mut args = self.vmaf_args.clone();
         if !args.iter().any(|a| a.contains("n_threads")) {
             // default n_threads to all cores
             args.push(format!("n_threads={}", num_cpus::get()).into());
         }
-        let mut combined = args.join(":");
-        combined.insert_str(0, "libvmaf=");
-        combined
+        let mut lavfi = args.join(":");
+        lavfi.insert_str(0, "libvmaf=");
+
+        let scale_1080p = !args.iter().any(|a| a.contains("model"))
+            && distorted_width.map_or(false, |w| w < 1728);
+
+        if scale_1080p {
+            // upscale both streams to 1080p, as this resolution is what the default
+            // vmaf model is designed to work with
+            lavfi.insert_str(
+                0,
+                "[0:v]scale=1920:-1:flags=bicubic[dis];[1:v]scale=1920:-1:flags=bicubic[ref];[dis][ref]",
+            );
+        }
+
+        lavfi
     }
 }
 
@@ -33,14 +47,14 @@ fn vmaf_lavfi() {
     let vmaf = Vmaf {
         vmaf_args: vec!["n_threads=5".into(), "n_subsample=4".into()],
     };
-    assert_eq!(vmaf.ffmpeg_lavfi(), "libvmaf=n_threads=5:n_subsample=4");
+    assert_eq!(vmaf.ffmpeg_lavfi(None), "libvmaf=n_threads=5:n_subsample=4");
 }
 
 #[test]
 fn vmaf_lavfi_default() {
     let vmaf = Vmaf { vmaf_args: vec![] };
     let expected = format!("libvmaf=n_threads={}", num_cpus::get());
-    assert_eq!(vmaf.ffmpeg_lavfi(), expected);
+    assert_eq!(vmaf.ffmpeg_lavfi(None), expected);
 }
 
 #[test]
@@ -49,5 +63,46 @@ fn vmaf_lavfi_include_n_threads() {
         vmaf_args: vec!["log_path=output.xml".into()],
     };
     let expected = format!("libvmaf=log_path=output.xml:n_threads={}", num_cpus::get());
-    assert_eq!(vmaf.ffmpeg_lavfi(), expected);
+    assert_eq!(vmaf.ffmpeg_lavfi(None), expected);
+}
+
+/// Low resolution videos should be upscaled to 1080p
+#[test]
+fn vmaf_lavfi_small_width() {
+    let vmaf = Vmaf {
+        vmaf_args: vec!["n_threads=5".into(), "n_subsample=4".into()],
+    };
+    assert_eq!(
+        vmaf.ffmpeg_lavfi(Some(1280)),
+        "[0:v]scale=1920:-1:flags=bicubic[dis];\
+         [1:v]scale=1920:-1:flags=bicubic[ref];\
+         [dis][ref]libvmaf=n_threads=5:n_subsample=4"
+    );
+}
+
+/// If user has overriden the model, don't presume to scale
+#[test]
+fn vmaf_lavfi_small_width_custom_model() {
+    let vmaf = Vmaf {
+        vmaf_args: vec![
+            "model=version=foo".into(),
+            "n_threads=5".into(),
+            "n_subsample=4".into(),
+        ],
+    };
+    assert_eq!(
+        vmaf.ffmpeg_lavfi(Some(1280)),
+        "libvmaf=model=version=foo:n_threads=5:n_subsample=4"
+    );
+}
+
+#[test]
+fn vmaf_lavfi_1080p() {
+    let vmaf = Vmaf {
+        vmaf_args: vec!["n_threads=5".into(), "n_subsample=4".into()],
+    };
+    assert_eq!(
+        vmaf.ffmpeg_lavfi(Some(1920)),
+        "libvmaf=n_threads=5:n_subsample=4"
+    );
 }

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -159,7 +159,7 @@ pub async fn run(
             &sample,
             svt.vfilter.as_deref(),
             &encoded_sample,
-            &vmaf.ffmpeg_lavfi(),
+            &vmaf.ffmpeg_lavfi(ffprobe::probe(&encoded_sample).width),
             svt.pix_format,
         )?;
         let mut vmaf_score = -1.0;

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -49,7 +49,10 @@ pub async fn vmaf(
     bar.enable_steady_tick(100);
     bar.set_message("vmaf running, ");
 
-    let duration = ffprobe::probe(&reference).duration;
+    let dprobe = ffprobe::probe(&distorted);
+    let duration = dprobe
+        .duration
+        .or_else(|_| ffprobe::probe(&reference).duration);
     if let Ok(d) = duration {
         bar.set_length(d.as_secs());
     }
@@ -58,7 +61,7 @@ pub async fn vmaf(
         &reference,
         reference_vfilter.as_deref(),
         &distorted,
-        &vmaf.ffmpeg_lavfi(),
+        &vmaf.ffmpeg_lavfi(dprobe.width),
         PixelFormat::Yuv420p10le,
     )?;
     let mut vmaf_score = -1.0;

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -16,7 +16,7 @@ pub fn run(
     reference: &Path,
     reference_vfilter: Option<&str>,
     distorted: &Path,
-    lavfi: &str,
+    filter_complex: &str,
     pix_fmt: PixelFormat,
 ) -> anyhow::Result<impl Stream<Item = VmafOut>> {
     let (yuv_out, yuv_pipe) = yuv::pipe(reference, pix_fmt, reference_vfilter)?;
@@ -35,7 +35,7 @@ pub fn run(
         .kill_on_drop(true)
         .arg2("-i", distorted)
         .arg2("-i", "-")
-        .arg2("-lavfi", lavfi)
+        .arg2("-filter_complex", filter_complex)
         .arg2("-f", "null")
         .arg("-")
         .stdin(yuv_out)


### PR DESCRIPTION
* Add `--vmaf-width` option which sets the video resolution width to use in VMAF analysis.
* When using the default VMAF model, improve VMAF accuracy for sub-1k resolutions by defaulting
  `--vmaf-width=1920` whenever video resolution width is less than 1728. This will result in lower 
  VMAF scores than were reported for such videos in previous versions.
* Strip debug symbols in release builds by default which reduces binary size _(requires rustc 1.59)_.

Resolves #27 