### PR TITLE
Rework vmaf-width into vmaf-scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,9 @@
   downmix input audio streams to stereo.
 * After encoding print per-stream sizes in addition to the file size & percent.
 * When defaulting the output file don't use input extension if it is _avi, y4m, ivf_, use mp4 instead.
-* Add `--vmaf-width` option which sets the video resolution width to use in VMAF analysis.
-* When using the default VMAF model, improve VMAF accuracy for sub-1k resolutions by defaulting
-  `--vmaf-width=1920` whenever video resolution width is less than 1728. This will result in lower 
-  VMAF scores than were reported for such videos in previous versions.
+* Add `--vmaf-scale` option which sets the video resolution scale to use in VMAF analysis.
+  May be set to `auto` auto scale based on model & resolution, `none` no scaling or custom `WxH`
+  format, e.g. `1920x1080`. `auto` should be best unless a custom model is being used.
 * Fix clearing _crf-search_ progress bar output on error.
 * Add predicted video stream percent reduction to _auto-encode_ search progress bar after a successful search.
 * Strip debug symbols in release builds by default which reduces binary size _(requires rustc 1.59)_.

--- a/src/command/args/svt.rs
+++ b/src/command/args/svt.rs
@@ -280,7 +280,7 @@ fn to_svt_args_default_over_3m() {
         has_audio: true,
         max_audio_channels: None,
         fps: Ok(30.0),
-        width: Some(720),
+        resolution: Some((1280, 720)),
     };
 
     let SvtArgs {
@@ -321,7 +321,7 @@ fn to_svt_args_default_under_3m() {
         has_audio: true,
         max_audio_channels: None,
         fps: Ok(24.0),
-        width: Some(720),
+        resolution: Some((1280, 720)),
     };
 
     let SvtArgs {

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -159,7 +159,7 @@ pub async fn run(
             &sample,
             svt.vfilter.as_deref(),
             &encoded_sample,
-            &vmaf.ffmpeg_lavfi(ffprobe::probe(&encoded_sample).width),
+            &vmaf.ffmpeg_lavfi(ffprobe::probe(&encoded_sample).resolution),
             svt.pix_format,
         )?;
         let mut vmaf_score = -1.0;

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -61,7 +61,7 @@ pub async fn vmaf(
         &reference,
         reference_vfilter.as_deref(),
         &distorted,
-        &vmaf.ffmpeg_lavfi(dprobe.width),
+        &vmaf.ffmpeg_lavfi(dprobe.resolution),
         PixelFormat::Yuv420p10le,
     )?;
     let mut vmaf_score = -1.0;


### PR DESCRIPTION
Add `--vmaf-scale` option which sets the video resolution scale to use in VMAF analysis. May be set to `auto` auto scale based on model & resolution, `none` no scaling or custom `WxH` format, e.g. `1920x1080`. `auto` should be best unless a custom model is being used.


Resolves #32 