### PR TITLE
sample: swap -ss option to before the input file

### DIFF
--- a/src/sample.rs
+++ b/src/sample.rs
@@ -38,8 +38,8 @@ pub async fn copy(
 
     let out = Command::new("ffmpeg")
         .arg("-y")
-        .arg2("-i", input)
         .arg2("-ss", sample_start.as_secs().to_string())
+        .arg2("-i", input)
         .arg2("-t", SAMPLE_SIZE_S.to_string())
         .arg2("-c:v", "copy")
         .arg("-an")


### PR DESCRIPTION
Makes ffmpeg seek instantly to the point in time of the video file the
sample is to be taken from; using it as an output option instead makes
the video decode from the beginning up until that point.

Saving 40 minutes of processing time seems typical for some of my
Blu-ray files.