### PR TITLE
Use -ss input & -frames:v instead of -t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (v0.3.2)
+* Improve sample generation speed & frame duration accuracy.
+
 # v0.3.1
 * Fix some cases where ffmpeg progress & VMAF score output parsing failed.
 * Fix some edge cases where crf-search would succeed exceeding the specified `--max-encoded-percent`.


### PR DESCRIPTION
Improve sample speed & duration accuracy, see https://github.com/alexheretic/ab-av1/issues/36#issuecomment-1146634936

Resolves #36 
Closes #38 