### PR TITLE
auto-encode: show last attempt crf when failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (v0.3.3)
+* Show more info auto-encode fails to find a suitable crf.
+
 # v0.3.2
 * Improve sample generation speed & frame duration accuracy.
 

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -209,10 +209,6 @@ impl Sample {
         if quiet {
             return;
         }
-        bar.println(self.attempt_string(min_vmaf, max_encoded_percent));
-    }
-
-    pub fn attempt_string(&self, min_vmaf: f32, max_encoded_percent: f32) -> String {
         let crf_label = style("- crf").dim();
         let mut crf = style(self.crf);
         let vmaf_label = style("VMAF").dim();
@@ -230,7 +226,9 @@ impl Sample {
             percent = percent.red().bright();
         }
 
-        format!("{crf_label} {crf} {vmaf_label} {vmaf:.2} {open}{percent}{close}")
+        bar.println(format!(
+            "{crf_label} {crf} {vmaf_label} {vmaf:.2} {open}{percent}{close}"
+        ))
     }
 }
 

--- a/src/command/crf_search/err.rs
+++ b/src/command/crf_search/err.rs
@@ -1,0 +1,51 @@
+use crate::command::crf_search::Sample;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum Error {
+    NoGoodCrf { last: Sample },
+    Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Other(err)
+    }
+}
+
+impl From<tokio::task::JoinError> for Error {
+    fn from(err: tokio::task::JoinError) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoGoodCrf { .. } => "Failed to find a suitable crf".fmt(f),
+            Self::Other(err) => err.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+macro_rules! ensure_other {
+    ($condition:expr, $reason:expr) => {
+        if !$condition {
+            return Err($crate::command::crf_search::err::Error::Other(
+                anyhow::anyhow!($reason),
+            ));
+        }
+    };
+}
+pub(crate) use ensure_other;
+
+macro_rules! ensure_or_no_good_crf {
+    ($condition:expr, $last_sample:expr) => {
+        if !$condition {
+            return Err($crate::command::crf_search::err::Error::NoGoodCrf { last: $last_sample });
+        }
+    };
+}
+pub(crate) use ensure_or_no_good_crf;


### PR DESCRIPTION
When running `auto-encode` command each crf attempt is not printed. This mean if no suitable crf is found it isn't clear how close the attempts got.

This pr adds the info from the final crf attempt as the progress bar message coloured red for the failing bits.

## Before
```
  Searching 00:00:11 ################## (sampling crf 32, eta 0s)
Error: Failed to find a suitable crf
```

## After
```
  Searching 00:00:11 ################## (crf 32, VMAF 92.99, size 7%)
Error: Failed to find a suitable crf
```

Resolves #35 