### PR TITLE
Add AVIF support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Unreleased (v0.4.4)
-* Update to clap v4 which changes help/about output & reduces binary size.
-* Print _crf-search_ attempts even when stderr is not a tty.
-* Add _crf-search_, _auto-encode_ & _vmaf_ command support for encoding images into avif.
+* Add _crf-search_, _auto-encode_, _encode_ & _vmaf_ command support for encoding images into avif.
   This works in the same way as videos, example:
   ```
   ab-av1 auto-encode -i pic.jpg
   ```
   The default encoder svt-av1 has some dimension limitations which may cause this to fail. `-e libaom-av1` also works and supports more dimensions.
+* Convert to yuv444p10le pixel format when calculating VMAF for accuracy and compatibility.
+* Update to clap v4 which changes help/about output & reduces binary size.
+* Print _crf-search_ attempts even when stderr is not a tty.
 
 # v0.4.3
 * Fix terminal breaking sometimes after exitting early.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Unreleased (v0.4.4)
 * Update to clap v4 which changes help/about output & reduces binary size.
-* Print crf-search attempts even when stderr is not a tty.
+* Print _crf-search_ attempts even when stderr is not a tty.
+* Add _crf-search_, _auto-encode_ & _vmaf_ command support for encoding images into avif.
+  This works in the same way as videos, example:
+  ```
+  ab-av1 auto-encode -i pic.jpg
+  ```
+  The default encoder svt-av1 has some dimension limitations which may cause this to fail. `-e libaom-av1` also works and supports more dimensions.
 
 # v0.4.3
 * Fix terminal breaking sometimes after exitting early.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,18 +504,18 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "serde"
-version = "1.0.146"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df50b7a60a0ad48e1b42eb38373eac8ff785d619fb14db917b4e63d5439361f"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.146"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a714fd32ba1d66047ce7d53dabd809e9922d538f9047de13cc4cffca47b36205"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+checksum = "e6e481ccbe3dea62107216d0d1138bb8ad8e5e5c43009a098bd1990272c497b0"
 
 [[package]]
 name = "itoa"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Uses _ffmpeg_, _svt-av1_ & _vmaf_.
 Also supports other ffmpeg compatible encoders like libx265 & libx264.
 
 ### Command: auto-encode
-Automatically determine the best crf to deliver the min-vmaf and use it to encode a video.
+Automatically determine the best crf to deliver the min-vmaf and use it to encode a video or image.
 
 Two phases:
 * [crf-search](#command-crf-search) to determine the best --crf value
@@ -45,7 +45,7 @@ ab-av1 sample-encode [OPTIONS] -i <INPUT> --crf <CRF> --preset <PRESET>
 ```
 
 ### Command: encode
-Simple invocation of ffmpeg & SvtAv1EncApp to encode a video.
+Simple invocation of ffmpeg & SvtAv1EncApp to encode a video or image.
 
 ```
 ab-av1 encode [OPTIONS] -i <INPUT> --crf <CRF> --preset <PRESET>
@@ -53,6 +53,8 @@ ab-av1 encode [OPTIONS] -i <INPUT> --crf <CRF> --preset <PRESET>
 
 ### Command: vmaf
 Simple full calculation of VMAF score distorted file vs reference file.
+
+Works with videos and images.
 
 ```
 ab-av1 vmaf --reference <REFERENCE> --distorted <DISTORTED>

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -460,6 +460,7 @@ impl std::str::FromStr for KeyInterval {
 pub enum PixelFormat {
     Yuv420p10le,
     Yuv420p,
+    Yuv444p,
 }
 
 impl PixelFormat {
@@ -467,6 +468,7 @@ impl PixelFormat {
         match self {
             Self::Yuv420p10le => "yuv420p10le",
             Self::Yuv420p => "yuv420p",
+            Self::Yuv444p => "yuv444p",
         }
     }
 
@@ -474,6 +476,7 @@ impl PixelFormat {
         match self {
             Self::Yuv420p10le => "10",
             Self::Yuv420p => "8",
+            Self::Yuv444p => "8",
         }
     }
 }

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -380,15 +380,6 @@ pub enum EncoderArgs<'a> {
     Ffmpeg(FfmpegEncodeArgs<'a>),
 }
 
-impl EncoderArgs<'_> {
-    pub fn pix_fmt(&self) -> PixelFormat {
-        match self {
-            Self::SvtAv1(arg) => arg.pix_fmt,
-            Self::Ffmpeg(arg) => arg.pix_fmt,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Preset {
     Number(u8),
@@ -460,23 +451,23 @@ impl std::str::FromStr for KeyInterval {
 pub enum PixelFormat {
     Yuv420p10le,
     Yuv420p,
-    Yuv444p,
+    Yuv444p10le,
 }
 
 impl PixelFormat {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Yuv420p10le => "yuv420p10le",
+            Self::Yuv444p10le => "yuv444p10le",
             Self::Yuv420p => "yuv420p",
-            Self::Yuv444p => "yuv444p",
         }
     }
 
     pub fn input_depth(self) -> &'static str {
         match self {
             Self::Yuv420p10le => "10",
+            Self::Yuv444p10le => "10",
             Self::Yuv420p => "8",
-            Self::Yuv444p => "8",
         }
     }
 }

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -544,6 +544,7 @@ fn to_svt_args_default_over_3m() {
         max_audio_channels: None,
         fps: Ok(30.0),
         resolution: Some((1280, 720)),
+        has_image_extension: false,
     };
 
     let SvtArgs {
@@ -588,6 +589,7 @@ fn to_svt_args_default_under_3m() {
         max_audio_channels: None,
         fps: Ok(24.0),
         resolution: Some((1280, 720)),
+        has_image_extension: false,
     };
 
     let SvtArgs {

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -35,10 +35,12 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
 
     search.quiet = true;
     let defaulting_output = encode.output.is_none();
-    let probe = ffprobe::probe(&search.args.input);
-    let output = encode
-        .output
-        .unwrap_or_else(|| default_output_from(&search.args, probe.duration.unwrap().is_zero()));
+    let output = encode.output.unwrap_or_else(|| {
+        default_output_from(
+            &search.args,
+            ffprobe::probe(&search.args.input).is_probably_an_image(),
+        )
+    });
 
     let bar = ProgressBar::new(12).with_style(
         ProgressStyle::default_bar()

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -12,7 +12,7 @@ use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::time::Duration;
 
-/// Automatically determine the best crf to deliver the min-vmaf and use it to encode a video.
+/// Automatically determine the best crf to deliver the min-vmaf and use it to encode a video or image.
 ///
 /// Two phases:
 /// * crf-search to determine the best --crf value

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -5,7 +5,7 @@ use crate::{
         PROGRESS_CHARS,
     },
     console_ext::style,
-    temporary,
+    ffprobe, temporary,
 };
 use clap::Parser;
 use console::style;
@@ -35,9 +35,10 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
 
     search.quiet = true;
     let defaulting_output = encode.output.is_none();
+    let probe = ffprobe::probe(&search.args.input);
     let output = encode
         .output
-        .unwrap_or_else(|| default_output_from(&search.args));
+        .unwrap_or_else(|| default_output_from(&search.args, probe.duration.unwrap().is_zero()));
 
     let bar = ProgressBar::new(12).with_style(
         ProgressStyle::default_bar()

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -70,7 +70,7 @@ pub async fn run(
     let enc_args = args.to_encoder_args(crf, &probe)?;
     let has_audio = probe.has_audio;
     if let Ok(d) = probe.duration {
-        bar.set_length(d.as_secs());
+        bar.set_length(d.as_secs().max(1));
     }
 
     // only downmix if achannels > 3

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -16,7 +16,7 @@ use std::{path::PathBuf, time::Duration};
 use tokio::fs;
 use tokio_stream::StreamExt;
 
-/// Simple invocation of ffmpeg & SvtAv1EncApp to encode a video.
+/// Simple invocation of ffmpeg & SvtAv1EncApp to encode a video or image.
 #[derive(Parser)]
 #[group(skip)]
 pub struct Args {

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -194,7 +194,7 @@ pub async fn run(
             &vmaf.ffmpeg_lavfi(ffprobe::probe(&encoded_sample).resolution),
             match input_is_image {
                 // 10le doesn't seem to work well for images
-                true => PixelFormat::Yuv420p,
+                true => PixelFormat::Yuv444p,
                 _ => enc_args.pix_fmt(),
             },
         )?;

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -192,11 +192,7 @@ pub async fn run(
             svt.vfilter.as_deref(),
             &encoded_sample,
             &vmaf.ffmpeg_lavfi(ffprobe::probe(&encoded_sample).resolution),
-            match input_is_image {
-                // 10le doesn't seem to work well for images
-                true => PixelFormat::Yuv444p,
-                _ => enc_args.pix_fmt(),
-            },
+            PixelFormat::Yuv444p10le,
         )?;
         let mut vmaf_score = -1.0;
         while let Some(vmaf) = vmaf.next().await {

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -1,6 +1,6 @@
 use crate::{
     command::{
-        args::{self, EncoderArgs},
+        args::{self, EncoderArgs, PixelFormat},
         PROGRESS_CHARS,
     },
     console_ext::style,
@@ -192,7 +192,11 @@ pub async fn run(
             svt.vfilter.as_deref(),
             &encoded_sample,
             &vmaf.ffmpeg_lavfi(ffprobe::probe(&encoded_sample).resolution),
-            enc_args.pix_fmt(),
+            match input_is_image {
+                // 10le doesn't seem to work well for images
+                true => PixelFormat::Yuv420p,
+                _ => enc_args.pix_fmt(),
+            },
         )?;
         let mut vmaf_score = -1.0;
         while let Some(vmaf) = vmaf.next().await {

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -141,6 +141,14 @@ pub async fn run(
         // encode sample
         bar.set_message("encoding,");
         let b = Instant::now();
+        let dest_ext = if duration.is_zero() {
+            "avif"
+        } else {
+            input
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .unwrap_or("mp4")
+        };
         let (encoded_sample, mut output) = match enc_args.clone() {
             EncoderArgs::SvtAv1(args) => {
                 let (sample, output) = svtav1::encode_sample(
@@ -159,6 +167,7 @@ pub async fn run(
                         ..args
                     },
                     temp_dir.clone(),
+                    dest_ext,
                 )?;
                 (sample, futures::StreamExt::boxed_local(output))
             }

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -82,6 +82,7 @@ pub async fn run(
 ) -> anyhow::Result<Output> {
     let input = Arc::new(svt.input.clone());
     let probe = ffprobe::probe(&input);
+    let input_is_image = probe.is_probably_an_image();
     let enc_args = svt.to_encoder_args(crf, &probe)?;
     let duration = probe.duration?;
     let fps = probe.fps?;
@@ -141,7 +142,7 @@ pub async fn run(
         // encode sample
         bar.set_message("encoding,");
         let b = Instant::now();
-        let dest_ext = if duration.is_zero() {
+        let dest_ext = if input_is_image {
             "avif"
         } else {
             input

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -14,6 +14,8 @@ use std::{path::PathBuf, time::Duration};
 use tokio_stream::StreamExt;
 
 /// Simple full calculation of VMAF score distorted file vs original file.
+///
+/// Works with videos and images.
 #[derive(Parser)]
 #[group(skip)]
 pub struct Args {

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -66,7 +66,7 @@ pub async fn vmaf(
         &vmaf.ffmpeg_lavfi(dprobe.resolution),
         match distorted_is_image {
             // 10le doesn't seem to work well for images
-            true => PixelFormat::Yuv420p,
+            true => PixelFormat::Yuv444p,
             false => PixelFormat::Yuv420p10le,
         },
     )?;

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -51,7 +51,6 @@ pub async fn vmaf(
     bar.set_message("vmaf running, ");
 
     let dprobe = ffprobe::probe(&distorted);
-    let distorted_is_image = dprobe.is_probably_an_image();
     let duration = dprobe
         .duration
         .or_else(|_| ffprobe::probe(&reference).duration);
@@ -64,11 +63,7 @@ pub async fn vmaf(
         reference_vfilter.as_deref(),
         &distorted,
         &vmaf.ffmpeg_lavfi(dprobe.resolution),
-        match distorted_is_image {
-            // 10le doesn't seem to work well for images
-            true => PixelFormat::Yuv444p,
-            false => PixelFormat::Yuv420p10le,
-        },
+        PixelFormat::Yuv444p10le,
     )?;
     let mut vmaf_score = -1.0;
     while let Some(vmaf) = vmaf.next().await {

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -41,11 +41,8 @@ pub fn encode_sample(
         input_args,
     }: FfmpegEncodeArgs,
     temp_dir: Option<PathBuf>,
+    dest_ext: &str,
 ) -> anyhow::Result<(PathBuf, impl Stream<Item = anyhow::Result<FfmpegOut>>)> {
-    let dest_ext = input
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .unwrap_or("mp4");
     let pre = pre_extension_name(&vcodec);
     let mut dest = match &preset {
         Some(p) => input.with_extension(format!("{pre}.crf{crf}.{p}.{dest_ext}")),

--- a/src/ffprobe.rs
+++ b/src/ffprobe.rs
@@ -62,14 +62,15 @@ pub fn probe(input: &Path) -> Ffprobe {
 }
 
 fn read_duration(probe: &ffprobe::FfProbe) -> anyhow::Result<Duration> {
-    let duration_s = probe
-        .format
-        .duration
-        .as_deref()
-        .context("ffprobe missing video duration")?
-        .parse::<f64>()
-        .context("invalid ffprobe video duration")?;
-    Ok(Duration::from_secs_f64(duration_s))
+    match probe.format.duration.as_deref() {
+        Some(duration_s) => {
+            let duration_f = duration_s
+                .parse::<f64>()
+                .context("invalid ffprobe video duration")?;
+            Ok(Duration::from_secs_f64(duration_f))
+        }
+        None => Ok(Duration::ZERO),
+    }
 }
 
 fn read_fps(probe: &ffprobe::FfProbe) -> anyhow::Result<f64> {

--- a/src/ffprobe.rs
+++ b/src/ffprobe.rs
@@ -12,10 +12,22 @@ pub struct Ffprobe {
     /// Video frame rate.
     pub fps: Result<f64, ProbeError>,
     pub resolution: Option<(u32, u32)>,
+    pub has_image_extension: bool,
+}
+
+impl Ffprobe {
+    pub fn is_probably_an_image(&self) -> bool {
+        self.has_image_extension || self.duration == Ok(Duration::ZERO)
+    }
 }
 
 /// Try to ffprobe the given input.
 pub fn probe(input: &Path) -> Ffprobe {
+    let has_image_extension = matches!(
+        input.extension().and_then(|ext| ext.to_str()),
+        Some("jpg" | "png" | "bmp" | "avif")
+    );
+
     let probe = match ffprobe::ffprobe(&input) {
         Ok(p) => p,
         Err(err) => {
@@ -25,6 +37,7 @@ pub fn probe(input: &Path) -> Ffprobe {
                 has_audio: true,
                 max_audio_channels: None,
                 resolution: None,
+                has_image_extension,
             }
         }
     };
@@ -58,6 +71,7 @@ pub fn probe(input: &Path) -> Ffprobe {
         has_audio,
         max_audio_channels,
         resolution,
+        has_image_extension,
     }
 }
 


### PR DESCRIPTION
This PR addresses #56.

Instead of erroring on input media with an unknown duration, we set it to zero and then treat all zero-length media as images.
There are currently some `unwrap`s that I'm not too happy about, but it "works on my machine™".