### PR TITLE
On windows don't set vmaf reference pix fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased (v0.4.5)
 * Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.
   Such samples will now encode to .mp4 in the same way _encode_ already did in this case.
+* Windows: Add workaround for missing VMAF distorted pixel format conversion, by using ffmpeg defaults for reference yuv pixel format.
 
 # v0.4.4
 * Add _crf-search_, _auto-encode_, _encode_ & _vmaf_ command support for encoding images into avif.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.23"
+version = "4.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb41c13df48950b20eb4cd0eefa618819469df1bffc49d11e8487c4ba0037e5"
+checksum = "60494cedb60cb47462c0ff7be53de32c0e42a6fc2c772184554fa12bd9489c03"
 dependencies = [
  "atty",
  "bitflags",

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -191,7 +191,11 @@ pub async fn run(
             svt.vfilter.as_deref(),
             &encoded_sample,
             &vmaf.ffmpeg_lavfi(ffprobe::probe(&encoded_sample).resolution),
-            PixelFormat::Yuv444p10le,
+            // Converting both distorted & reference to yuv444p10 seems to have the most
+            // consistent results. It seems particularly important for images.
+            // Windows: Distorted -> yuv is currently not supported (needs named-pipe-alike)
+            //          gets better results from ffmpeg inferring.
+            (cfg!(unix) || input_is_image).then_some(PixelFormat::Yuv444p10le),
         )?;
         let mut vmaf_score = -1.0;
         while let Some(vmaf) = vmaf.next().await {

--- a/src/svtav1.rs
+++ b/src/svtav1.rs
@@ -50,7 +50,7 @@ pub fn encode_sample(
     }
     temporary::add(&dest, TempKind::Keepable);
 
-    let (yuv_out, yuv_pipe) = yuv::pipe(input, pix_fmt, vfilter)?;
+    let (yuv_out, yuv_pipe) = yuv::pipe(input, Some(pix_fmt), vfilter)?;
 
     let svt = Command::new("SvtAv1EncApp")
         .kill_on_drop(true)
@@ -97,7 +97,7 @@ pub fn encode(
     let audio_codec = audio_codec
         .unwrap_or_else(|| default_audio_codec(input, output, downmix_to_stereo, has_audio));
 
-    let (yuv_out, yuv_pipe) = yuv::pipe(input, pix_fmt, vfilter)?;
+    let (yuv_out, yuv_pipe) = yuv::pipe(input, Some(pix_fmt), vfilter)?;
     let yuv_pipe = yuv_pipe.filter(Result::is_err);
 
     let mut svt = Command::new("SvtAv1EncApp")

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -12,12 +12,14 @@ use tokio_stream::{Stream, StreamExt};
 
 /// Calculate VMAF score by converting the original first to yuv.
 /// This can produce more accurate results than testing directly from original source.
+///
+/// `pix_fmt` is used for reference (and distorted on unix). `None` means no -pix_fmt is passed to ffmpeg.
 pub fn run(
     reference: &Path,
     reference_vfilter: Option<&str>,
     distorted: &Path,
     filter_complex: &str,
-    pix_fmt: PixelFormat,
+    pix_fmt: Option<PixelFormat>,
 ) -> anyhow::Result<impl Stream<Item = VmafOut>> {
     let (yuv_out, yuv_pipe) = yuv::pipe(reference, pix_fmt, reference_vfilter)?;
     let yuv_pipe = yuv_pipe.filter_map(VmafOut::ignore_ok);

--- a/src/yuv.rs
+++ b/src/yuv.rs
@@ -10,13 +10,13 @@ use tokio_stream::Stream;
 /// ffmpeg yuv4mpegpipe returning the stdout & [`FfmpegProgress`] stream.
 pub fn pipe(
     input: &Path,
-    pix_fmt: PixelFormat,
+    pix_fmt: Option<PixelFormat>,
     vfilter: Option<&str>,
 ) -> anyhow::Result<(Stdio, impl Stream<Item = anyhow::Result<FfmpegOut>>)> {
     let mut yuv4mpegpipe = Command::new("ffmpeg")
         .kill_on_drop(true)
         .arg2("-i", input)
-        .arg2("-pix_fmt", pix_fmt.as_str())
+        .arg2_opt("-pix_fmt", pix_fmt.map(|pf| pf.as_str()))
         .arg2_opt("-vf", vfilter)
         .arg2("-strict", "-1")
         .arg2("-f", "yuv4mpegpipe")
@@ -44,7 +44,7 @@ pub mod unix {
     /// ffmpeg yuv4mpegpipe returning the temporary fifo path & [`FfmpegProgress`] stream.
     pub fn pipe_to_fifo(
         input: &Path,
-        pix_fmt: PixelFormat,
+        pix_fmt: Option<PixelFormat>,
     ) -> anyhow::Result<(PathBuf, impl Stream<Item = anyhow::Result<FfmpegOut>>)> {
         let fifo = PathBuf::from(format!(
             "/tmp/ab-av1-{}.fifo",
@@ -56,7 +56,7 @@ pub mod unix {
         let yuv4mpegpipe = Command::new("ffmpeg")
             .kill_on_drop(true)
             .arg2("-i", input)
-            .arg2("-pix_fmt", pix_fmt.as_str())
+            .arg2_opt("-pix_fmt", pix_fmt.map(|pf| pf.as_str()))
             .arg2("-strict", "-1")
             .arg2("-f", "yuv4mpegpipe")
             .arg("-y")


### PR DESCRIPTION
Workaround for #63 

Having an equivalent to unix named pipes would be better, but this may help in the meantime.