### PR TITLE
Fix ffmpeg avi sample extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased (v0.4.5)
+* Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.
+  Such samples will now encode to .mp4 in the same way _encode_ already did in this case.
+
 # v0.4.4
 * Add _crf-search_, _auto-encode_, _encode_ & _vmaf_ command support for encoding images into avif.
   This works in the same way as videos, example:

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -38,7 +38,8 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
     let defaulting_output = encode.output.is_none();
     let output = encode.output.unwrap_or_else(|| {
         default_output_from(
-            &search.args,
+            &search.args.input,
+            &search.args.encoder,
             ffprobe::probe(&search.args.input).is_probably_an_image(),
         )
     });


### PR DESCRIPTION
* Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.
  Such samples will now encode to .mp4 in the same way _encode_ already did in this case.

Related to another issue mentioned in #63 