### PR TITLE
Implement windows named pipe vmaf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Optimise pixel format choice for VMAF comparisons. _E.g. if both videos are yuv420p use that instead of yuv444p10le_.
 * Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.
   Such samples will now encode to .mp4 in the same way _encode_ already did in this case.
-* Windows: Support VMAF pixel format conversion for both distorted and reference, as done on Linux.
+* Windows: Support VMAF pixel format conversion for both distorted and reference. Gives more consistently accurate results, and brings Windows in line with Linux functionality.
 
 # v0.4.4
 * Add _crf-search_, _auto-encode_, _encode_ & _vmaf_ command support for encoding images into avif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Optimise pixel format choice for VMAF comparisons. _E.g. if both videos are yuv420p use that instead of yuv444p10le_.
 * Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.
   Such samples will now encode to .mp4 in the same way _encode_ already did in this case.
+* Windows: Support VMAF pixel format conversion for both distorted and reference, as done on Linux.
 
 # v0.4.4
 * Add _crf-search_, _auto-encode_, _encode_ & _vmaf_ command support for encoding images into avif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased (v0.4.5)
-* Optimise pixel format choice for VMAF comparisons. _E.g. if both videos are yuv420p use that instead of yuv444p10le_.
+* Optimise pixel format choice for VMAF comparisons. Can significantly improve VMAF fps.
+  _E.g. if both videos are yuv420p use that instead of yuv444p10le_.
 * Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.
   Such samples will now encode to .mp4 in the same way _encode_ already did in this case.
 * Windows: Support VMAF pixel format conversion for both distorted and reference. Gives more consistently accurate results, and brings Windows in line with Linux functionality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
   _E.g. if both videos are yuv420p use that instead of yuv444p10le_.
 * Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.
   Such samples will now encode to .mp4 in the same way _encode_ already did in this case.
-* Windows: Support VMAF pixel format conversion for both distorted and reference. Gives more consistently accurate results, and brings Windows in line with Linux functionality.
+* Windows: Support VMAF pixel format conversion for both distorted and reference.
+  Gives more consistently accurate results and brings Windows in line with Linux functionality.
 
 # v0.4.4
 * Add _crf-search_, _auto-encode_, _encode_ & _vmaf_ command support for encoding images into avif.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
@@ -379,9 +379,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.23"
+version = "4.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb41c13df48950b20eb4cd0eefa618819469df1bffc49d11e8487c4ba0037e5"
+checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
 dependencies = [
  "atty",
  "bitflags",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "8e8b3801309262e8184d9687fb697586833e939767aea0dda89f5a8e650e8bd7"
 dependencies = [
  "itoa",
  "ryu",
@@ -552,6 +552,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -628,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",
@@ -640,6 +650,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,14 @@ time = { version = "0.3", features = ["parsing", "macros"] }
 tokio = { version = "1.15", features = ["rt", "macros", "process", "fs", "signal"] }
 tokio-process-stream = "0.3"
 tokio-stream = "0.1"
+rand = "0.8.5"
 
 [target.'cfg(unix)'.dependencies]
 unix-named-pipe = "0.2"
-rand = "0.8.5"
+
+[target.'cfg(windows)'.dependencies.tokio]
+version = "1.15"
+features = ["net"]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ futures = "0.3.19"
 humantime = "2.1"
 indicatif = "0.17"
 once_cell = "1.9"
+rand = "0.8.5"
 serde_json = "1.0.78"
 shell-escape = "0.1.5"
 time = { version = "0.3", features = ["parsing", "macros"] }
 tokio = { version = "1.15", features = ["rt", "macros", "process", "fs", "signal"] }
 tokio-process-stream = "0.3"
 tokio-stream = "0.1"
-rand = "0.8.5"
 
 [target.'cfg(unix)'.dependencies]
 unix-named-pipe = "0.2"

--- a/src/yuv.rs
+++ b/src/yuv.rs
@@ -31,6 +31,62 @@ pub fn pipe(
     Ok((stdout, stream))
 }
 
+#[cfg(windows)]
+pub mod windows {
+    use super::*;
+
+    pub fn named_pipe(
+        input: &Path,
+        pix_fmt: PixelFormat,
+    ) -> anyhow::Result<(String, impl Stream<Item = anyhow::Result<FfmpegOut>>)> {
+        use rand::distributions::{Alphanumeric, DistString};
+        use rand::thread_rng;
+
+        let mut in_name = Alphanumeric.sample_string(&mut thread_rng(), 12);
+        in_name.insert_str(0, r"\\.\pipe\ab-av1-in-");
+
+        let mut in_server = tokio::net::windows::named_pipe::ServerOptions::new()
+            .access_outbound(false)
+            .first_pipe_instance(true)
+            .max_instances(1)
+            .create(&in_name)?;
+
+        let out_name = in_name.replacen("-in-", "-out-", 1);
+        let mut out_server = tokio::net::windows::named_pipe::ServerOptions::new()
+            .access_inbound(false)
+            .first_pipe_instance(true)
+            .max_instances(1)
+            .create(&out_name)?;
+
+        tokio::spawn(async move {
+            in_server.connect().await.unwrap();
+            in_server.readable().await.unwrap();
+            out_server.connect().await.unwrap();
+            out_server.writable().await.unwrap();
+            tokio::io::copy(&mut in_server, &mut out_server)
+                .await
+                .unwrap();
+        });
+
+        let yuv4mpegpipe = Command::new("ffmpeg")
+            .kill_on_drop(true)
+            .arg2("-i", input)
+            .arg2("-pix_fmt", pix_fmt.as_str())
+            .arg2("-strict", "-1")
+            .arg2("-f", "yuv4mpegpipe")
+            .arg("-y")
+            .arg(&in_name)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("ffmpeg yuv4mpegpipe")?;
+        let stream = FfmpegOut::stream(yuv4mpegpipe, "ffmpeg yuv4mpegpipe");
+
+        Ok((out_name, stream))
+    }
+}
+
 #[cfg(unix)]
 pub mod unix {
     use super::*;

--- a/src/yuv.rs
+++ b/src/yuv.rs
@@ -39,8 +39,10 @@ pub mod windows {
         input: &Path,
         pix_fmt: PixelFormat,
     ) -> anyhow::Result<(String, impl Stream<Item = anyhow::Result<FfmpegOut>>)> {
-        use rand::distributions::{Alphanumeric, DistString};
-        use rand::thread_rng;
+        use rand::{
+            distributions::{Alphanumeric, DistString},
+            thread_rng,
+        };
 
         let mut in_name = Alphanumeric.sample_string(&mut thread_rng(), 12);
         in_name.insert_str(0, r"\\.\pipe\ab-av1-in-");


### PR DESCRIPTION
Brings windows in line with Linux for VMAF both converting reference & distorted into yuv streams before passing to libvmaf.

Gives more consistently accurate results and brings Windows in line with Linux functionality.

Resolves #65
Resolves #63 