### PR TITLE
Sampling: Use full input video when sample time is 85%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   _E.g. if both videos are yuv420p use that instead of yuv444p10le_.
 * Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.
   Such samples will now encode to .mp4 in the same way _encode_ already did in this case.
+* When sampling use full input video when sample time would be >= 85% of the total (down from 100%).
 * Windows: Support VMAF pixel format conversion for both distorted and reference.
   Gives more consistently accurate results and brings Windows in line with Linux functionality.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8b3801309262e8184d9687fb697586833e939767aea0dda89f5a8e650e8bd7"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -93,8 +93,8 @@ pub async fn run(
     let temp_dir = sample_args.temp_dir;
 
     let (samples, full_pass) = {
-        if SAMPLE_SIZE * samples as _ >= duration {
-            // if the input is a lower duration than the samples just encode the whole thing
+        if SAMPLE_SIZE * samples as _ >= Duration::from_secs_f64(duration.as_secs_f64() * 0.85) {
+            // if the sample time is most of the full input time just encode the whole thing
             (1, true)
         } else {
             (samples, false)


### PR DESCRIPTION
When sampling use full input video when sample time would be >= 85% of the total (down from 100%).

Resolves #71 