### PR TITLE
Default output to .mkv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased (v0.4.5)
+* Default to .mp4 output format for all inputs (except .mkv which will continue to output .mkv by default).
+  This also applies to ffmpeg encoder sample output format. The previous behavior used the input extension
+  which may not have supported av1 (e.g. .m2ts).
+* For _auto-encode_ use the output extension also for ffmpeg encoder sample outputs if applicable.
 * Optimise pixel format choice for VMAF comparisons. Can significantly improve VMAF fps.
   _E.g. if both videos are yuv420p use that instead of yuv444p10le_.
 * Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.
   Such samples will now encode to .mp4 in the same way _encode_ already did in this case.
 * When sampling use full input video when sample time would be >= 85% of the total (down from 100%).
+* Eliminate repeated redundant ffprobe calls.
 * Windows: Support VMAF pixel format conversion for both distorted and reference.
   Gives more consistently accurate results and brings Windows in line with Linux functionality.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Unreleased (v0.4.5)
-* Default to .mp4 output format for all inputs (except .mkv which will continue to output .mkv by default).
+* Default to .mkv output format for all inputs (except .mkv which will continue to output .mkv by default).
   This also applies to ffmpeg encoder sample output format. The previous behavior used the input extension
   which may not have supported av1 (e.g. .m2ts).
 * For _auto-encode_ use the output extension also for ffmpeg encoder sample outputs if applicable.
 * Optimise pixel format choice for VMAF comparisons. Can significantly improve VMAF fps.
   _E.g. if both videos are yuv420p use that instead of yuv444p10le_.
-* Fix overridden `--encoder` .avi file samples using the same extension, which will generally not work.
-  Such samples will now encode to .mp4 in the same way _encode_ already did in this case.
 * When sampling use full input video when sample time would be >= 85% of the total (down from 100%).
 * Eliminate repeated redundant ffprobe calls.
 * Windows: Support VMAF pixel format conversion for both distorted and reference.

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -18,7 +18,7 @@ use std::{
 pub struct EncodeToOutput {
     /// Output file, by default the same as input with `.av1` before the extension.
     ///
-    /// E.g. if unspecified: -i vid.mp4 --> vid.av1.mp4
+    /// E.g. if unspecified: -i vid.mkv --> vid.av1.mkv
     #[arg(short, long)]
     pub output: Option<PathBuf>,
 

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -10,7 +10,7 @@ use crate::{
 use clap::Parser;
 use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 /// Automatically determine the best crf to deliver the min-vmaf and use it to encode a video or image.
 ///
@@ -36,11 +36,13 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
 
     search.quiet = true;
     let defaulting_output = encode.output.is_none();
+    let input_probe = Arc::new(ffprobe::probe(&search.args.input));
+
     let output = encode.output.unwrap_or_else(|| {
         default_output_from(
             &search.args.input,
             &search.args.encoder,
-            ffprobe::probe(&search.args.input).is_probably_an_image(),
+            input_probe.is_probably_an_image(),
         )
     });
 
@@ -56,7 +58,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
         bar.println(style!("Encoding {out}").dim().to_string());
     }
 
-    let best = match crf_search::run(&search, bar.clone()).await {
+    let best = match crf_search::run(&search, input_probe.clone(), bar.clone()).await {
         Ok(best) => best,
         Err(err) => {
             if let crf_search::Error::NoGoodCrf { last } = &err {
@@ -113,6 +115,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
                 ..encode
             },
         },
+        input_probe,
         &bar,
     )
     .await

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -1,7 +1,7 @@
 use crate::{
     command::{
         args, crf_search,
-        encode::{self, default_output_from},
+        encode::{self, default_output_name},
         PROGRESS_CHARS,
     },
     console_ext::style,
@@ -39,12 +39,13 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
     let input_probe = Arc::new(ffprobe::probe(&search.args.input));
 
     let output = encode.output.unwrap_or_else(|| {
-        default_output_from(
+        default_output_name(
             &search.args.input,
             &search.args.encoder,
             input_probe.is_probably_an_image(),
         )
     });
+    search.sample.set_extension_from_output(&output);
 
     let bar = ProgressBar::new(12).with_style(
         ProgressStyle::default_bar()

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -50,14 +50,14 @@ pub struct Args {
     #[clap(flatten)]
     pub sample: args::Sample,
 
-    #[arg(skip)]
-    pub quiet: bool,
-
     #[clap(flatten)]
     pub vmaf: args::Vmaf,
+
+    #[arg(skip)]
+    pub quiet: bool,
 }
 
-pub async fn crf_search(args: Args) -> anyhow::Result<()> {
+pub async fn crf_search(mut args: Args) -> anyhow::Result<()> {
     let bar = ProgressBar::new(12).with_style(
         ProgressStyle::default_bar()
             .template("{spinner:.cyan.bold} {elapsed_precise:.bold} {wide_bar:.cyan/blue} ({msg}eta {eta})")?
@@ -65,6 +65,8 @@ pub async fn crf_search(args: Args) -> anyhow::Result<()> {
     );
 
     let probe = ffprobe::probe(&args.args.input);
+    args.sample
+        .set_extension_from_input(&args.args.input, &probe);
 
     let best = run(&args, probe.into(), bar.clone()).await;
     bar.finish();

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -153,20 +153,20 @@ pub async fn run(
     Ok(())
 }
 
-/// * vid.mkv -> "mkv"
-/// * vid.??? -> "mp4"
+/// * vid.mp4 -> "mp4"
+/// * vid.??? -> "mkv"
 /// * image.??? -> "avif"
 pub fn default_output_ext(input: &Path, is_image: bool) -> &'static str {
     if is_image {
         return "avif";
     }
     match input.extension().and_then(|e| e.to_str()) {
-        Some("mkv") => "mkv",
-        _ => "mp4",
+        Some("mp4") => "mp4",
+        _ => "mkv",
     }
 }
 
-/// E.g. vid.mp4 -> "vid.av1.mp4"
+/// E.g. vid.mkv -> "vid.av1.mkv"
 pub fn default_output_name(input: &Path, encoder: &Encoder, is_image: bool) -> PathBuf {
     let pre = ffmpeg::pre_extension_name(encoder.as_str());
     let ext = default_output_ext(input, is_image);

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     console_ext::style,
     ffmpeg::{self, FfmpegEncodeArgs},
-    ffprobe,
+    ffprobe::{self, Ffprobe},
     process::FfmpegOut,
     sample,
     svtav1::{self, SvtArgs},
@@ -38,7 +38,7 @@ use tokio_stream::StreamExt;
 #[group(skip)]
 pub struct Args {
     #[clap(flatten)]
-    pub svt: args::Encode,
+    pub args: args::Encode,
 
     /// Encoder constant rate factor (1-63). Lower means better quality.
     #[arg(long)]
@@ -67,28 +67,29 @@ pub async fn sample_encode(args: Args) -> anyhow::Result<()> {
     );
     bar.enable_steady_tick(Duration::from_millis(100));
 
-    run(args, bar).await?;
+    let probe = ffprobe::probe(&args.args.input);
+    run(args, probe.into(), bar).await?;
     Ok(())
 }
 
 pub async fn run(
     Args {
-        svt,
+        args,
         crf,
         sample: sample_args,
         keep,
         stdout_format,
         vmaf,
     }: Args,
+    input_probe: Arc<Ffprobe>,
     bar: ProgressBar,
 ) -> anyhow::Result<Output> {
-    let input = Arc::new(svt.input.clone());
-    let probe = ffprobe::probe(&input);
-    let input_pixel_format = probe.pixel_format();
-    let input_is_image = probe.is_probably_an_image();
-    let enc_args = svt.to_encoder_args(crf, &probe)?;
-    let duration = probe.duration?;
-    let fps = probe.fps?;
+    let input = Arc::new(args.input.clone());
+    let input_pixel_format = input_probe.pixel_format();
+    let input_is_image = input_probe.is_probably_an_image();
+    let enc_args = args.to_encoder_args(crf, &input_probe)?;
+    let duration = input_probe.duration.clone()?;
+    let fps = input_probe.fps.clone()?;
     let samples = sample_args.sample_count(duration).max(1);
     let temp_dir = sample_args.temp_dir;
 
@@ -146,18 +147,18 @@ pub async fn run(
         bar.set_message("encoding,");
         let b = Instant::now();
         let (encoded_sample, mut output) = match enc_args.clone() {
-            EncoderArgs::SvtAv1(args) => {
+            EncoderArgs::SvtAv1(enc_args) => {
                 let (sample, output) = svtav1::encode_sample(
                     SvtArgs {
                         input: &sample,
-                        ..args
+                        ..enc_args
                     },
                     temp_dir.clone(),
                 )?;
                 (sample, futures::StreamExt::boxed_local(output))
             }
-            EncoderArgs::Ffmpeg(args) => {
-                let default_output = default_output_from(&input, &svt.encoder, input_is_image);
+            EncoderArgs::Ffmpeg(enc_args) => {
+                let default_output = default_output_from(&input, &args.encoder, input_is_image);
                 let dest_ext = default_output
                     .extension()
                     .and_then(|ext| ext.to_str())
@@ -166,7 +167,7 @@ pub async fn run(
                 let (sample, output) = ffmpeg::encode_sample(
                     FfmpegEncodeArgs {
                         input: &sample,
-                        ..args
+                        ..enc_args
                     },
                     temp_dir.clone(),
                     dest_ext,
@@ -189,7 +190,7 @@ pub async fn run(
         bar.set_message("vmaf running,");
         let mut vmaf = vmaf::run(
             &sample,
-            svt.vfilter.as_deref(),
+            args.vfilter.as_deref(),
             &encoded_sample,
             &vmaf.ffmpeg_lavfi(ffprobe::probe(&encoded_sample).resolution),
             enc_args
@@ -254,7 +255,7 @@ pub async fn run(
         eprintln!(
             "\n{} {}\n",
             style("Encode with:").dim(),
-            style(svt.encode_hint(crf)).dim().italic(),
+            style(args.encode_hint(crf)).dim().italic(),
         );
         // stdout result
         stdout_format.print_result(

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -165,7 +165,7 @@ pub async fn run(
                         ..enc_args
                     },
                     temp_dir.clone(),
-                    sample_args.extension.as_deref().unwrap_or("mp4"),
+                    sample_args.extension.as_deref().unwrap_or("mkv"),
                 )?;
                 (sample, futures::StreamExt::boxed_local(output))
             }

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -77,7 +77,7 @@ pub fn encode_sample(
     Ok((dest, stream))
 }
 
-/// Encode to mp4 including re-encoding audio with libopus, if present.
+/// Encode to output.
 pub fn encode(
     FfmpegEncodeArgs {
         input,

--- a/src/svtav1.rs
+++ b/src/svtav1.rs
@@ -75,7 +75,7 @@ pub fn encode_sample(
     Ok((dest, yuv_pipe.merge(svt)))
 }
 
-/// Encode to mp4 including re-encoding audio with libopus, if present.
+/// Encode to output (e.g. mkv).
 pub fn encode(
     SvtArgs {
         input,
@@ -144,9 +144,9 @@ pub fn encode(
         .spawn()
         .context("ffmpeg to-output")?;
 
-    let to_mp4 = FfmpegOut::stream(to_output, "ffmpeg to-output");
+    let to_output_stream = FfmpegOut::stream(to_output, "ffmpeg to-output");
 
-    Ok(yuv_pipe.merge(svt).merge(to_mp4))
+    Ok(yuv_pipe.merge(svt).merge(to_output_stream))
 }
 
 pub fn default_audio_codec(


### PR DESCRIPTION
New logic for determining output & ffmpeg sample output extension/container.

* If -o is specified use the same extension.
* If input is .mp4 use .mp4.
* Otherwise use .mkv.

Resolves #72 