### PR TITLE
Encode mkv outputs with the "cues" seek index at the front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   This also applies to ffmpeg encoder sample output format. The previous behavior used the input extension
   which may not have supported av1 (e.g. .m2ts).
 * For _auto-encode_ use the output extension also for ffmpeg encoder sample outputs if applicable.
+* Encode mkv outputs with the "cues" seek index at the front to optimise stream usage.
 * Optimise pixel format choice for VMAF comparisons. Can significantly improve VMAF fps.
   _E.g. if both videos are yuv420p use that instead of yuv444p10le_.
 * When sampling use full input video when sample time would be >= 85% of the total (down from 100%).

--- a/src/svtav1.rs
+++ b/src/svtav1.rs
@@ -92,7 +92,9 @@ pub fn encode(
     audio_codec: Option<&str>,
     downmix_to_stereo: bool,
 ) -> anyhow::Result<impl Stream<Item = anyhow::Result<FfmpegOut>>> {
-    let add_faststart = output.extension().and_then(|e| e.to_str()) == Some("mp4");
+    let output_ext = output.extension().and_then(|e| e.to_str());
+    let add_faststart = output_ext == Some("mp4");
+    let add_cues_to_front = output_ext == Some("mkv");
 
     let audio_codec = audio_codec
         .unwrap_or_else(|| default_audio_codec(input, output, downmix_to_stereo, has_audio));
@@ -137,6 +139,7 @@ pub fn encode(
         .arg2("-c:v", "copy")
         .arg2_if(audio_codec == "libopus", "-b:a", "128k")
         .arg2_if(add_faststart, "-movflags", "+faststart")
+        .arg2_if(add_cues_to_front, "-cues_to_front", "y")
         .arg(output)
         .stdin(svt_out)
         .stdout(Stdio::null())


### PR DESCRIPTION
Encode mkv outputs with the "cues" seek index at the front to optimise stream usage.

I was going to do this later... but then I just did it.

Resolves #76 