### PR TITLE
Auto build ab-av1.exe releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: Rust
 
 on:
-  # push:
-  #   branches: [ main ]
-  # pull_request:
-  #   branches: [ main ]
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: Rust
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  # push:
+  #   branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Release
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,5 @@ jobs:
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: README.md
-        asset_name: the-readme
         tag: ${{ github.ref }}
         overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,11 @@ jobs:
     steps:
     - run: rustup update stable
     - uses: actions/checkout@v2
-    - run: cargo build --release --locked
+    - run: cargo build --locked
+    - run: dir target
     - uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/ab-av1.exe
+        file: target/debug/ab-av1.exe
         tag: ${{ github.ref }}
         overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Rust
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  win-bin:
+    name: Build Windows binary
+    runs-on: windows-latest
+    steps:
+    - run: rustup update stable
+    - uses: actions/checkout@v2
+    - run: cargo build --release --locked
+    - if: startsWith(github.ref, 'refs/tags/')
+      uses: fnkr/github-action-ghr@v1
+      env:
+        GHR_PATH: target/ab-av1.exe
+        GHR_REPLACE: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,13 @@ jobs:
     name: Build Windows binary
     runs-on: windows-latest
     steps:
-    - run: rustup update stable
+    # - run: rustup update stable
     - uses: actions/checkout@v2
-    - run: cargo build --release --locked
-    - if: startsWith(github.ref, 'refs/tags/')
-      uses: fnkr/github-action-ghr@v1
-      env:
-        GHR_PATH: target/ab-av1.exe
-        GHR_REPLACE: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # - run: cargo build --release --locked
+    - uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: README.md
+        asset_name: the-readme
+        tag: ${{ github.ref }}
+        overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ jobs:
     name: Build Windows binary
     runs-on: windows-latest
     steps:
-    # - run: rustup update stable
+    - run: rustup update stable
     - uses: actions/checkout@v2
-    # - run: cargo build --release --locked
+    - run: cargo build --release --locked
     - uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: README.md
+        file: target/ab-av1.exe
         tag: ${{ github.ref }}
         overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,10 @@ jobs:
     steps:
     - run: rustup update stable
     - uses: actions/checkout@v2
-    - run: cargo build --locked
-    - run: dir target
+    - run: cargo build --release --locked
     - uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/debug/ab-av1.exe
+        file: target/release/ab-av1.exe
         tag: ${{ github.ref }}
         overwrite: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Eliminate repeated redundant ffprobe calls.
 * Windows: Support VMAF pixel format conversion for both distorted and reference.
   Gives more consistently accurate results and brings Windows in line with Linux functionality.
+* Windows: ab-av1.exe binaries will now be automatically built and attached to releases.
 
 # v0.4.4
 * Add _crf-search_, _auto-encode_, _encode_ & _vmaf_ command support for encoding images into avif.


### PR DESCRIPTION
Automatically build and add **ab-av1.exe** binaries to new releases. The first one should turn up for **v0.5.0**.

Resolves #75 