### PR TITLE
Predict video stream size instead of file size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased (v0.5.1)
 * Change encoded size prediction logic to estimate video stream size only. Change text to clarify this.
 * Improve video size prediction logic to account for samples that do not turn out as 20s.
+* Fix ffmpeg output size parsing kB inaccuracy.
 
 # v0.5.0
 * Default to .mkv output format for all inputs (except .mp4 which will continue to output .mp4 by default).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased (v0.5.1)
-* Change encoded size prediction logic to estimate video stream size (or image size) only. Change text to clarify this.
+* Change encoded size prediction logic to estimate video stream size (or image size) only.
+  This should be much more consistent than the previous method. 
+  Change _crf-search_, _sample-encode_ result text to clarify this.
 * Improve video size prediction logic to account for samples that do not turn out as 20s.
 * Fix full-pass sample encode progress bar.
 * Use label "Full pass" instead of "Sample 1/1" when doing a full pass _sample-encode_.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Unreleased (v0.5.1)
 * Change encoded size prediction logic to estimate video stream size only. Change text to clarify this.
 * Improve video size prediction logic to account for samples that do not turn out as 20s.
-* Fix ffmpeg output size parsing kB inaccuracy.
 * Fix full-pass sample encode progress bar.
 * Use label "Full pass" instead of "Sample 1/1" when doing a full pass _sample-encode_.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased (v0.5.1)
+* Change encoded size prediction logic to estimate video stream size only. Change text to clarify this.
+* Improve video size prediction logic to account for samples that do not turn out as 20s.
+
 # v0.5.0
 * Default to .mkv output format for all inputs (except .mp4 which will continue to output .mp4 by default).
   This also applies to ffmpeg encoder sample output format. The previous behavior used the input extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 * Change encoded size prediction logic to estimate video stream size only. Change text to clarify this.
 * Improve video size prediction logic to account for samples that do not turn out as 20s.
 * Fix ffmpeg output size parsing kB inaccuracy.
+* Fix full-pass sample encode progress bar.
+* Use label "Full pass" instead of "Sample 1/1" when doing a full pass _sample-encode_.
 
 # v0.5.0
 * Default to .mkv output format for all inputs (except .mp4 which will continue to output .mp4 by default).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased (v0.5.1)
-* Change encoded size prediction logic to estimate video stream size only. Change text to clarify this.
+* Change encoded size prediction logic to estimate video stream size (or image size) only. Change text to clarify this.
 * Improve video size prediction logic to account for samples that do not turn out as 20s.
 * Fix full-pass sample encode progress bar.
 * Use label "Full pass" instead of "Sample 1/1" when doing a full pass _sample-encode_.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.28"
+version = "4.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94eecf2f2d0e0220737d9e6d8530da1e903b97dde58ebaf749262e85ce133c9"
+checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
  "bitflags",
  "clap_derive",

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -73,8 +73,8 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
                 if last.enc.vmaf < search.min_vmaf {
                     vmaf = vmaf.red();
                 }
-                let mut percent = style!("{:.0}%", last.enc.predicted_encode_percent);
-                if last.enc.predicted_encode_percent > search.max_encoded_percent as _ {
+                let mut percent = style!("{:.0}%", last.enc.encode_percent);
+                if last.enc.encode_percent > search.max_encoded_percent as _ {
                     percent = percent.red();
                 }
                 bar.finish_with_message(format!(
@@ -95,7 +95,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
         "crf {}, VMAF {:.2}, size {}",
         style(best.crf).green(),
         style(best.enc.vmaf).green(),
-        style(format!("{:.0}%", best.enc.predicted_encode_percent)).green(),
+        style(format!("{:.0}%", best.enc.encode_percent)).green(),
     ));
     temporary::clean_all().await;
 

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -142,7 +142,7 @@ pub async fn run(
             enc: sample_task??,
         };
         crf_attempts.push(sample.clone());
-        let sample_small_enough = sample.enc.predicted_encode_percent <= *max_encoded_percent as _;
+        let sample_small_enough = sample.enc.encode_percent <= *max_encoded_percent as _;
 
         if sample.enc.vmaf > *min_vmaf {
             // good
@@ -224,7 +224,7 @@ impl Sample {
         let mut crf = style(self.crf);
         let vmaf_label = style("VMAF").dim();
         let mut vmaf = style(self.enc.vmaf);
-        let mut percent = style!("{:.0}%", self.enc.predicted_encode_percent);
+        let mut percent = style!("{:.0}%", self.enc.encode_percent);
         let open = style("(").dim();
         let close = style(")").dim();
 
@@ -232,7 +232,7 @@ impl Sample {
             crf = crf.red().bright();
             vmaf = vmaf.red().bright();
         }
-        if self.enc.predicted_encode_percent > max_encoded_percent as _ {
+        if self.enc.encode_percent > max_encoded_percent as _ {
             crf = crf.red().bright();
             percent = percent.red().bright();
         }
@@ -258,12 +258,10 @@ impl StdoutFormat {
                 let crf = style(crf).bold().green();
                 let vmaf = style(enc.vmaf).bold().green();
                 let size = style(HumanBytes(enc.predicted_encode_size)).bold().green();
-                let percent = style!("{}%", enc.predicted_encode_percent.round())
-                    .bold()
-                    .green();
+                let percent = style!("{}%", enc.encode_percent.round()).bold().green();
                 let time = style(HumanDuration(enc.predicted_encode_time)).bold();
                 println!(
-                    "crf {crf} VMAF {vmaf:.2} predicted full encode size {size} ({percent}) taking {time}"
+                    "crf {crf} VMAF {vmaf:.2} predicted video stream size {size} ({percent}) taking {time}"
                 );
             }
         }

--- a/src/process.rs
+++ b/src/process.rs
@@ -121,7 +121,7 @@ fn parse_label_substr<'a>(label: &str, line: &'a str) -> Option<&'a str> {
 fn parse_label_size(label: &str, line: &str) -> Option<u64> {
     let size = parse_label_substr(label, line)?;
     let kbs: u64 = size.strip_suffix("kB")?.parse().ok()?;
-    Some(kbs * 1000)
+    Some(kbs * 1024)
 }
 
 /// Output chunk storage.
@@ -205,8 +205,8 @@ fn parse_ffmpeg_stream_sizes() {
     assert_eq!(
         FfmpegOut::try_parse(out),
         Some(FfmpegOut::StreamSizes {
-            video: 2897022 * 1000,
-            audio: 537162 * 1000,
+            video: 2897022 * 1024,
+            audio: 537162 * 1024,
             subtitle: 0,
             other: 0,
         })

--- a/src/process.rs
+++ b/src/process.rs
@@ -121,7 +121,7 @@ fn parse_label_substr<'a>(label: &str, line: &'a str) -> Option<&'a str> {
 fn parse_label_size(label: &str, line: &str) -> Option<u64> {
     let size = parse_label_substr(label, line)?;
     let kbs: u64 = size.strip_suffix("kB")?.parse().ok()?;
-    Some(kbs * 1024)
+    Some(kbs * 1000)
 }
 
 /// Output chunk storage.
@@ -205,8 +205,8 @@ fn parse_ffmpeg_stream_sizes() {
     assert_eq!(
         FfmpegOut::try_parse(out),
         Some(FfmpegOut::StreamSizes {
-            video: 2897022 * 1024,
-            audio: 537162 * 1024,
+            video: 2897022 * 1000,
+            audio: 537162 * 1000,
             subtitle: 0,
             other: 0,
         })


### PR DESCRIPTION
* Change encoded size prediction logic to estimate video stream size only. Change text to clarify this.
* Improve video size prediction logic to account for samples that do not turn out as 20s.

May resolve #79 