### PR TITLE
Support decimal crf in sample-encode, encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (v0.5.3)
+* Support decimal crf values in _sample-encode_, _encode_ subcommands (note svt-av1 only supports integer crf).
+
 # v0.5.2
 * Fix ffprobe duration conversion error scenarios panicking.
 * Tweak encoded size prediction logic to consider both input file size & encoded sample duration.

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -118,7 +118,7 @@ fn parse_enc_arg(arg: &str) -> anyhow::Result<String> {
 }
 
 impl Encode {
-    pub fn to_encoder_args(&self, crf: u8, probe: &Ffprobe) -> anyhow::Result<EncoderArgs<'_>> {
+    pub fn to_encoder_args(&self, crf: f32, probe: &Ffprobe) -> anyhow::Result<EncoderArgs<'_>> {
         match self.encoder {
             Encoder::SvtAv1 => Ok(EncoderArgs::SvtAv1(self.to_svt_args(crf, probe)?)),
             Encoder::Ffmpeg(ref vcodec) => Ok(EncoderArgs::Ffmpeg(self.to_ffmpeg_args(
@@ -129,7 +129,7 @@ impl Encode {
         }
     }
 
-    pub fn encode_hint(&self, crf: u8) -> String {
+    pub fn encode_hint(&self, crf: f32) -> String {
         let Self {
             encoder,
             input,
@@ -183,7 +183,7 @@ impl Encode {
         hint
     }
 
-    fn to_svt_args(&self, crf: u8, probe: &Ffprobe) -> anyhow::Result<SvtArgs<'_>> {
+    fn to_svt_args(&self, crf: f32, probe: &Ffprobe) -> anyhow::Result<SvtArgs<'_>> {
         ensure!(
             self.enc_args.is_empty(),
             "--enc args cannot be used with svt-av1, instead use --svt"
@@ -231,7 +231,7 @@ impl Encode {
     fn to_ffmpeg_args(
         &self,
         vcodec: Arc<str>,
-        crf: u8,
+        crf: f32,
         probe: &Ffprobe,
     ) -> anyhow::Result<FfmpegEncodeArgs<'_>> {
         ensure!(
@@ -581,11 +581,11 @@ fn to_svt_args_default_over_3m() {
         keyint,
         scd,
         args,
-    } = svt.to_svt_args(32, &probe).expect("to_svt_args");
+    } = svt.to_svt_args(32.0, &probe).expect("to_svt_args");
 
     assert_eq!(input, svt.input);
     assert_eq!(vfilter, Some("scale=320:-1,fps=film"));
-    assert_eq!(crf, 32);
+    assert_eq!(crf, 32.0);
     assert_eq!(preset, 8);
     assert_eq!(pix_fmt, PixelFormat::Yuv420p10le);
     assert_eq!(keyint, Some(240)); // based off filter fps
@@ -627,11 +627,11 @@ fn to_svt_args_default_under_3m() {
         keyint,
         scd,
         args,
-    } = svt.to_svt_args(32, &probe).expect("to_svt_args");
+    } = svt.to_svt_args(32.0, &probe).expect("to_svt_args");
 
     assert_eq!(input, svt.input);
     assert_eq!(vfilter, None);
-    assert_eq!(crf, 32);
+    assert_eq!(crf, 32.0);
     assert_eq!(preset, 7);
     assert_eq!(pix_fmt, PixelFormat::Yuv420p);
     assert_eq!(keyint, None);

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -110,7 +110,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
     encode::run(
         encode::Args {
             args: search.args,
-            crf: best.crf,
+            crf: best.crf.into(),
             encode: args::EncodeToOutput {
                 output: Some(output),
                 ..encode

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -30,7 +30,7 @@ pub struct Args {
 
     /// Encoder constant rate factor (1-63). Lower means better quality.
     #[arg(long)]
-    pub crf: u8,
+    pub crf: f32,
 
     #[clap(flatten)]
     pub encode: args::EncodeToOutput,

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -41,7 +41,7 @@ pub struct Args {
 
     /// Encoder constant rate factor (1-63). Lower means better quality.
     #[arg(long)]
-    pub crf: u8,
+    pub crf: f32,
 
     #[clap(flatten)]
     pub sample: args::Sample,

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -22,7 +22,7 @@ pub struct FfmpegEncodeArgs<'a> {
     pub vcodec: Arc<str>,
     pub vfilter: Option<&'a str>,
     pub pix_fmt: PixelFormat,
-    pub crf: u8,
+    pub crf: f32,
     pub preset: Option<Arc<str>>,
     pub output_args: Vec<Arc<String>>,
     pub input_args: Vec<Arc<String>>,

--- a/src/process.rs
+++ b/src/process.rs
@@ -286,6 +286,7 @@ impl_arg_string_display!(u8);
 impl_arg_string_display!(u16);
 impl_arg_string_display!(u32);
 impl_arg_string_display!(i32);
+impl_arg_string_display!(f32);
 
 impl ArgString for Arc<str> {
     fn arg_string(&self) -> Cow<'_, OsStr> {

--- a/src/svtav1.rs
+++ b/src/svtav1.rs
@@ -22,7 +22,7 @@ pub struct SvtArgs<'a> {
     pub input: &'a Path,
     pub vfilter: Option<&'a str>,
     pub pix_fmt: PixelFormat,
-    pub crf: u8,
+    pub crf: f32,
     pub preset: u8,
     pub keyint: Option<i32>,
     pub scd: u8,


### PR DESCRIPTION
Supports using decimal crf in _sample-encode_ & _encode_ subcommands.  Note svt-av1 only supports integer crf. _crf-search_ remains an integer search.

See #83 