### PR TITLE
Add crf-search `--crf-increment` & `--thorough` args: Allow decimal crf search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-# Unreleased (v0.5.3)
+# Unreleased (v0.6.0)
 * Support decimal crf values in _sample-encode_, _encode_ subcommands (note svt-av1 only supports integer crf).
 * Use mkv containers for all lossless samples. Previously mp4 samples were used for mp4 inputs, however in all test cases
   mkv 20s samples were better quality. This change improves accuracy for all mp4 input files.
+* Add _crf-search_, _auto-encode_ arg `--crf-increment`. Previously this would always be 1.
+  Defaults to **1** for av1 encoders, **0.1** otherwise.
+* Add _crf-search_, _auto-encode_ arg ``--thorough` which more exhaustively searches to find
+  a crf value close to the specified min-vmaf.
 
 # v0.5.2
 * Fix ffprobe duration conversion error scenarios panicking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 * Use mkv containers for all lossless samples. Previously mp4 samples were used for mp4 inputs, however in all test cases
   mkv 20s samples were better quality. This change improves accuracy for all mp4 input files.
 * Add _crf-search_, _auto-encode_ arg `--crf-increment`. Previously this would always be 1.
-  Defaults to **1** for av1 encoders, **0.1** otherwise.
-* Add _crf-search_, _auto-encode_ arg ``--thorough` which more exhaustively searches to find
+  Defaults to **1**. -e libx264, libx265 & libvpx-vp9 default to **0.1**.
+* Add _crf-search_, _auto-encode_ arg `--thorough` which more exhaustively searches to find
   a crf value close to the specified min-vmaf.
 
 # v0.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   Defaults to **1**. -e libx264, libx265 & libvpx-vp9 default to **0.1**.
 * Add _crf-search_, _auto-encode_ arg `--thorough` which more exhaustively searches to find
   a crf value close to the specified min-vmaf.
+* Default `--max-crf` to **46** for libx264 & libx265 encoders.
 
 # v0.5.2
 * Fix ffprobe duration conversion error scenarios panicking.

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -362,6 +362,16 @@ impl Encoder {
             Self::Ffmpeg(vcodec) => vcodec,
         }
     }
+
+    /// Returns default crf-increment.
+    ///
+    /// Generally 0.1 if codec supports decimal crf.
+    pub fn default_crf_increment(&self) -> f32 {
+        match self.as_str() {
+            "libx264" | "libx265" | "libvpx-vp9" => 0.1,
+            _ => 1.0,
+        }
+    }
 }
 
 impl std::str::FromStr for Encoder {

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -372,6 +372,14 @@ impl Encoder {
             _ => 1.0,
         }
     }
+
+    pub fn default_max_crf(&self) -> f32 {
+        match self.as_str() {
+            "libx264" | "libx265" => 46.0,
+            // Works well for svt-av1
+            _ => 55.0,
+        }
+    }
 }
 
 impl std::str::FromStr for Encoder {

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -1,6 +1,7 @@
 use crate::{
     ffmpeg::FfmpegEncodeArgs,
     ffprobe::{Ffprobe, ProbeError},
+    float::TerseF32,
     svtav1::SvtArgs,
 };
 use anyhow::ensure;
@@ -150,7 +151,7 @@ impl Encode {
         if let Encoder::Ffmpeg(vcodec) = encoder {
             write!(hint, " -e {vcodec}").unwrap();
         }
-        write!(hint, " -i {input} --crf {crf}").unwrap();
+        write!(hint, " -i {input} --crf {}", TerseF32(crf)).unwrap();
 
         if let Some(preset) = preset {
             write!(hint, " --preset {preset}").unwrap();

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -79,7 +79,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
                 }
                 bar.finish_with_message(format!(
                     "crf {}, VMAF {vmaf:.2}, size {percent}",
-                    style(last.crf).red(),
+                    style(last.crf()).red(),
                 ));
             }
             bar.finish();
@@ -93,7 +93,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
     );
     bar.finish_with_message(format!(
         "crf {}, VMAF {:.2}, size {}",
-        style(best.crf).green(),
+        style(best.crf()).green(),
         style(best.enc.vmaf).green(),
         style(format!("{:.0}%", best.enc.encode_percent)).green(),
     ));
@@ -110,7 +110,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
     encode::run(
         encode::Args {
             args: search.args,
-            crf: best.crf.into(),
+            crf: best.crf(),
             encode: args::EncodeToOutput {
                 output: Some(output),
                 ..encode

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -117,11 +117,7 @@ pub async fn run(
 ) -> Result<Sample, Error> {
     ensure_other!(min_crf < max_crf, "Invalid --min-crf & --max-crf");
 
-    let crf_increment = match crf_increment {
-        Some(inc) => *inc,
-        None if args.encoder.as_str().contains("av1") => 1.0,
-        None => 0.1,
-    };
+    let crf_increment = crf_increment.unwrap_or_else(|| args.encoder.default_crf_increment());
     let min_q = q_from_crf(*min_crf, crf_increment);
     let max_q = q_from_crf(*max_crf, crf_increment);
     let mut q: u64 = (min_q + max_q) / 2;

--- a/src/command/crf_search/err.rs
+++ b/src/command/crf_search/err.rs
@@ -32,6 +32,7 @@ impl std::error::Error for Error {}
 
 macro_rules! ensure_other {
     ($condition:expr, $reason:expr) => {
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
         if !$condition {
             return Err($crate::command::crf_search::err::Error::Other(
                 anyhow::anyhow!($reason),

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -1,6 +1,7 @@
 //! ffmpeg encoding logic
 use crate::{
     command::args::PixelFormat,
+    float::TerseF32,
     process::{CommandExt, FfmpegOut},
     svtav1,
     temporary::{self, TempKind},
@@ -44,9 +45,10 @@ pub fn encode_sample(
     dest_ext: &str,
 ) -> anyhow::Result<(PathBuf, impl Stream<Item = anyhow::Result<FfmpegOut>>)> {
     let pre = pre_extension_name(&vcodec);
+    let crf_str = format!("{}", TerseF32(crf)).replace('.', "_");
     let mut dest = match &preset {
-        Some(p) => input.with_extension(format!("{pre}.crf{crf}.{p}.{dest_ext}")),
-        None => input.with_extension(format!("{pre}.crf{crf}.{dest_ext}")),
+        Some(p) => input.with_extension(format!("{pre}.crf{crf_str}.{p}.{dest_ext}")),
+        None => input.with_extension(format!("{pre}.crf{crf_str}.{dest_ext}")),
     };
     if let (Some(mut temp), Some(name)) = (temp_dir, dest.file_name()) {
         temp.push(name);

--- a/src/float.rs
+++ b/src/float.rs
@@ -1,0 +1,22 @@
+/// f32 wrapper that displays minimal decimal places.
+#[derive(Debug, Clone, Copy)]
+pub struct TerseF32(pub f32);
+
+impl std::fmt::Display for TerseF32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if pseudo_int(self.0.into()) {
+            write!(f, "{:.0}", self.0)
+        } else if pseudo_int(f64::from(self.0) * 10.0) {
+            write!(f, "{:.1}", self.0)
+        } else if pseudo_int(f64::from(self.0) * 100.0) {
+            write!(f, "{:.2}", self.0)
+        } else {
+            self.0.fmt(f)
+        }
+    }
+}
+
+#[inline]
+fn pseudo_int(f: f64) -> bool {
+    !(0.0002..=0.9998).contains(&f.fract())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod console_ext;
 mod duration;
 mod ffmpeg;
 mod ffprobe;
+mod float;
 mod process;
 mod sample;
 mod svtav1;


### PR DESCRIPTION
* Add _crf-search_, _auto-encode_ arg `--crf-increment`. Previously this would always be 1.
  Defaults to **1**. -e libx264, libx265 & libvpx-vp9 default to **0.1**.
* Add _crf-search_, _auto-encode_ arg `--thorough` which more exhaustively searches to find
  a crf value close to the specified min-vmaf.

Resolves #83 