### PR TITLE
Use mkv for all lossless samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased (v0.5.3)
 * Support decimal crf values in _sample-encode_, _encode_ subcommands (note svt-av1 only supports integer crf).
+* Use mkv containers for all lossless samples. Previously mp4 samples were used for mp4 inputs, however in all test cases
+  mkv 20s samples were better quality. This change improves accuracy for all mp4 input files.
 
 # v0.5.2
 * Fix ffprobe duration conversion error scenarios panicking.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,18 +526,18 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,6 +1,5 @@
 //! ffmpeg logic
 use crate::{
-    command::encode::default_output_ext,
     process::{ensure_success, CommandExt},
     temporary::{self, TempKind},
 };
@@ -21,9 +20,9 @@ pub async fn copy(
     frames: u32,
     temp_dir: Option<PathBuf>,
 ) -> anyhow::Result<PathBuf> {
-    let ext = default_output_ext(input, false); // not an image
-    let mut dest =
-        input.with_extension(format!("sample{}+{frames}f.{ext}", sample_start.as_secs()));
+    // Always using mkv for the samples works better than, e.g. using mp4 for mp4s
+    // see https://github.com/alexheretic/ab-av1/issues/82#issuecomment-1337306325
+    let mut dest = input.with_extension(format!("sample{}+{frames}f.mkv", sample_start.as_secs()));
     if let (Some(mut temp), Some(name)) = (temp_dir, dest.file_name()) {
         temp.push(name);
         dest = temp;


### PR DESCRIPTION
Use mkv containers for all lossless samples. Previously mp4 samples were used for mp4 inputs, however in all test cases mkv 20s samples were better quality. This change improves accuracy for all mp4 input files.

See [test results & analysis](https://github.com/alexheretic/ab-av1/issues/82#issuecomment-1337306325).