### PR TITLE
Cache sample-encode results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Unreleased (v0.6.0)
-* Cache _sample-encode_ results in $CACHE_DIR/ab-av1 directory. This allows repeated same crf sample encoding
-  to be avoided when running _sample-encode_, _crf-search_ & _auto-encode_. E.g. repeating a _crf-search_ with
-  a different min-vmaf.<br/>
-  Caching is enabled by default. Can be disabled with `--cache false` or setting env var `AB_AV1_CACHE=false`.
 * Support decimal crf values in _sample-encode_, _encode_ subcommands (note svt-av1 only supports integer crf).
-* Use mkv containers for all lossless samples. Previously mp4 samples were used for mp4 inputs, however in all test cases
-  mkv 20s samples were better quality. This change improves accuracy for all mp4 input files.
 * Add _crf-search_, _auto-encode_ arg `--crf-increment`. Previously this would always be 1.
   Defaults to **1**. -e libx264, libx265 & libvpx-vp9 default to **0.1**.
 * Add _crf-search_, _auto-encode_ arg `--thorough` which more exhaustively searches to find
   a crf value close to the specified min-vmaf.
+* Cache _sample-encode_ results in $CACHE_DIR/ab-av1 directory. This allows repeated same crf sample encoding
+  to be avoided when running _sample-encode_, _crf-search_ & _auto-encode_. E.g. repeating a _crf-search_ with
+  a different min-vmaf.<br/>
+  Caching is enabled by default. Can be disabled with `--cache false` or setting env var `AB_AV1_CACHE=false`.
+* Use mkv containers for all lossless samples. Previously mp4 samples were used for mp4 inputs, however in all test cases
+  mkv 20s samples were better quality. This change improves accuracy for all mp4 input files.
 * Default `--max-crf` to **46** for libx264 & libx265 encoders.
 * Encode webm outputs with the "cues" seek index at the front to optimise stream usage (as done with mkv).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased (v0.6.0)
+* Cache _sample-encode_ results in $CACHE_DIR/ab-av1 directory. This allows repeated same crf sample encoding
+  to be avoided when running _sample-encode_, _crf-search_ & _auto-encode_. E.g. repeating a _crf-search_ with
+  a different min-vmaf.<br/>
+  Caching is enabled by default. Can be disabled with `--cache false` or setting env var `AB_AV1_CACHE=false`.
 * Support decimal crf values in _sample-encode_, _encode_ subcommands (note svt-av1 only supports integer crf).
 * Use mkv containers for all lossless samples. Previously mp4 samples were used for mp4 inputs, however in all test cases
   mkv 20s samples were better quality. This change improves accuracy for all mp4 input files.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-escape",
+ "sled",
  "time",
  "tokio",
  "tokio-process-stream",
@@ -92,6 +93,12 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -179,6 +186,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +292,16 @@ checksum = "b5d603974ab029fc75cebf00bfa06c9c6f49a6fb657f4f5f6a9fd6cbd76910a4"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -346,6 +394,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +466,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +515,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +538,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -502,6 +587,31 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -621,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
@@ -638,6 +748,12 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -693,6 +809,28 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -804,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes",
@@ -818,7 +956,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,15 +8,18 @@ version = "0.5.2"
 dependencies = [
  "anyhow",
  "atty",
+ "blake3",
  "clap",
  "clap_complete",
  "console",
+ "dirs",
  "ffprobe",
  "futures",
  "humantime",
  "indicatif",
  "once_cell",
  "rand",
+ "serde",
  "serde_json",
  "shell-escape",
  "time",
@@ -31,6 +34,18 @@ name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "atty"
@@ -54,6 +69,29 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake3"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bytes"
@@ -131,6 +169,53 @@ dependencies = [
  "once_cell",
  "terminal_size 0.1.17",
  "unicode-width",
+ "winapi",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
  "winapi",
 ]
 
@@ -258,6 +343,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -505,6 +600,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +711,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +754,26 @@ checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -729,6 +870,12 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rand = "0.8.5"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 shell-escape = "0.1.5"
+sled = "0.34.7"
 time = { version = "0.3", features = ["parsing", "macros"] }
 tokio = { version = "1.15", features = ["rt", "macros", "process", "fs", "signal"] }
 tokio-process-stream = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,19 @@ readme = "README.md"
 [dependencies]
 anyhow = "1.0.53"
 atty = "0.2.14"
+blake3 = "1.3.3"
 clap = { version = "4", features = ["derive", "env", "wrap_help"] }
 clap_complete = "4"
 console = "=0.15.1" # no lazy_static
+dirs = "4"
 ffprobe = "0.3"
 futures = "0.3.19"
 humantime = "2.1"
 indicatif = "0.17"
 once_cell = "1.9"
 rand = "0.8.5"
-serde_json = "1.0.78"
+serde = { version = "1.0.149", features = ["derive"] }
+serde_json = "1.0.89"
 shell-escape = "0.1.5"
 time = { version = "0.3", features = ["parsing", "macros"] }
 tokio = { version = "1.15", features = ["rt", "macros", "process", "fs", "signal"] }

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 use std::{
     collections::HashMap,
     fmt::{self, Write},
+    hash::Hasher,
     path::PathBuf,
     sync::Arc,
     time::Duration,
@@ -348,7 +349,7 @@ impl Encode {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Encoder {
     SvtAv1,
     Ffmpeg(Arc<str>),
@@ -406,9 +407,16 @@ impl EncoderArgs<'_> {
             Self::Ffmpeg(a) => a.pix_fmt,
         }
     }
+
+    pub fn sample_encode_hash(&self, state: &mut impl Hasher) {
+        match self {
+            Self::SvtAv1(a) => a.sample_encode_hash(state),
+            Self::Ffmpeg(a) => a.sample_encode_hash(state),
+        }
+    }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Preset {
     Number(u8),
     Name(Arc<str>),
@@ -434,7 +442,7 @@ impl std::str::FromStr for Preset {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum KeyInterval {
     Frames(i32),
     Duration(Duration),
@@ -475,7 +483,7 @@ impl std::str::FromStr for KeyInterval {
 }
 
 /// Ordered by ascending quality.
-#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[clap(rename_all = "lower")]
 pub enum PixelFormat {
     Yuv420p,

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -64,7 +64,12 @@ pub struct Args {
     pub crf_increment: Option<f32>,
 
     /// Enable sample-encode caching.
-    #[arg(long, default_value_t = true, action(ArgAction::Set))]
+    #[arg(
+        long,
+        default_value_t = true,
+        env = "AB_AV1_CACHE",
+        action(ArgAction::Set)
+    )]
     pub cache: bool,
 
     #[clap(flatten)]

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -168,6 +168,7 @@ pub async fn run(
             duration,
             input.extension(),
             input_len,
+            full_pass,
             &enc_args,
         )
         .await

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -53,7 +53,12 @@ pub struct Args {
     pub keep: bool,
 
     /// Enable sample-encode caching.
-    #[arg(long, default_value_t = true, action(ArgAction::Set))]
+    #[arg(
+        long,
+        default_value_t = true,
+        env = "AB_AV1_CACHE",
+        action(ArgAction::Set)
+    )]
     pub cache: bool,
 
     /// Stdout message format `human` or `json`.

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -1,3 +1,5 @@
+mod cache;
+
 use crate::{
     command::{
         args::{self, EncoderArgs, PixelFormat},
@@ -14,7 +16,7 @@ use crate::{
     SAMPLE_SIZE, SAMPLE_SIZE_S,
 };
 use anyhow::ensure;
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use console::style;
 use indicatif::{HumanBytes, HumanDuration, ProgressBar, ProgressStyle};
 use std::{
@@ -50,6 +52,10 @@ pub struct Args {
     #[arg(long)]
     pub keep: bool,
 
+    /// Enable sample-encode caching.
+    #[arg(long, default_value_t = true, action(ArgAction::Set))]
+    pub cache: bool,
+
     /// Stdout message format `human` or `json`.
     #[arg(long, value_enum, default_value_t = StdoutFormat::Human)]
     pub stdout_format: StdoutFormat,
@@ -79,6 +85,7 @@ pub async fn run(
         crf,
         sample: sample_args,
         keep,
+        cache,
         stdout_format,
         vmaf,
     }: Args,
@@ -88,6 +95,7 @@ pub async fn run(
     let input = Arc::new(args.input.clone());
     let input_pixel_format = input_probe.pixel_format();
     let input_is_image = input_probe.is_probably_an_image();
+    let input_len = fs::metadata(&*input).await?.len();
     let enc_args = args.to_encoder_args(crf, &input_probe)?;
     let duration = input_probe.duration.clone()?;
     let fps = input_probe.fps.clone()?;
@@ -112,12 +120,11 @@ pub async fn run(
     let sample_temp = temp_dir.clone();
     let sample_in = input.clone();
     tokio::task::spawn_local(async move {
-        for sample_idx in 0..samples {
-            if full_pass {
-                let full_sample = sample_full_pass(sample_in.clone()).await;
-                let _ = tx.send((sample_idx, full_sample));
-                break;
-            } else {
+        if full_pass {
+            // Use the entire video as a single sample
+            let _ = tx.send((0, Ok((sample_in.clone(), input_len))));
+        } else {
+            for sample_idx in 0..samples {
                 let sample = sample(
                     sample_in.clone(),
                     sample_idx,
@@ -150,100 +157,137 @@ pub async fn run(
         let (sample, sample_size) = sample?;
 
         // encode sample
-        bar.set_message("encoding,");
-        let b = Instant::now();
-        let (encoded_sample, mut output) = match enc_args.clone() {
-            EncoderArgs::SvtAv1(enc_args) => {
-                let (sample, output) = svtav1::encode_sample(
-                    SvtArgs {
-                        input: &sample,
-                        ..enc_args
-                    },
-                    temp_dir.clone(),
-                )?;
-                (sample, futures::StreamExt::boxed_local(output))
-            }
-            EncoderArgs::Ffmpeg(enc_args) => {
-                let (sample, output) = ffmpeg::encode_sample(
-                    FfmpegEncodeArgs {
-                        input: &sample,
-                        ..enc_args
-                    },
-                    temp_dir.clone(),
-                    sample_args.extension.as_deref().unwrap_or("mkv"),
-                )?;
-                (sample, futures::StreamExt::boxed_local(output))
-            }
-        };
-        while let Some(progress) = output.next().await {
-            if let FfmpegOut::Progress { time, fps, .. } = progress? {
-                bar.set_position(time.as_secs() + sample_idx * sample_duration_s * 2);
-                if fps > 0.0 {
-                    bar.set_message(format!("enc {fps} fps,"));
-                }
-            }
-        }
-        let encode_time = b.elapsed();
-        let encoded_size = fs::metadata(&encoded_sample).await?.len();
-        let encoded_probe = ffprobe::probe(&encoded_sample);
-
-        // calculate vmaf
-        bar.set_message("vmaf running,");
-        let mut vmaf = vmaf::run(
+        let result = match cache::cached_encode(
+            cache,
             &sample,
-            args.vfilter.as_deref(),
-            &encoded_sample,
-            &vmaf.ffmpeg_lavfi(encoded_probe.resolution),
-            enc_args
-                .pixel_format()
-                .max(input_pixel_format.unwrap_or(PixelFormat::Yuv444p10le)),
-        )?;
-        let mut vmaf_score = -1.0;
-        while let Some(vmaf) = vmaf.next().await {
-            match vmaf {
-                VmafOut::Done(score) => {
-                    vmaf_score = score;
-                    break;
-                }
-                VmafOut::Progress(FfmpegOut::Progress { time, fps, .. }) => {
-                    bar.set_position(
-                        sample_duration_s + time.as_secs() + sample_idx * sample_duration_s * 2,
-                    );
-                    if fps > 0.0 {
-                        bar.set_message(format!("vmaf {fps} fps,"));
+            duration,
+            input.extension(),
+            input_len,
+            &enc_args,
+        )
+        .await
+        {
+            (Some(result), _) => {
+                bar.set_position(sample_n * sample_duration_s * 2);
+                bar.println(
+                    style!(
+                        "- Sample {sample_n} ({:.0}%) vmaf {:.2} (cache)",
+                        100.0 * result.encoded_size as f32 / sample_size as f32,
+                        result.vmaf_score,
+                    )
+                    .dim()
+                    .to_string(),
+                );
+                result
+            }
+            (None, key) => {
+                bar.set_message("encoding,");
+                let b = Instant::now();
+                let (encoded_sample, mut output) = match enc_args.clone() {
+                    EncoderArgs::SvtAv1(enc_args) => {
+                        let (sample, output) = svtav1::encode_sample(
+                            SvtArgs {
+                                input: &sample,
+                                ..enc_args
+                            },
+                            temp_dir.clone(),
+                        )?;
+                        (sample, futures::StreamExt::boxed_local(output))
+                    }
+                    EncoderArgs::Ffmpeg(enc_args) => {
+                        let (sample, output) = ffmpeg::encode_sample(
+                            FfmpegEncodeArgs {
+                                input: &sample,
+                                ..enc_args
+                            },
+                            temp_dir.clone(),
+                            sample_args.extension.as_deref().unwrap_or("mkv"),
+                        )?;
+                        (sample, futures::StreamExt::boxed_local(output))
+                    }
+                };
+                while let Some(progress) = output.next().await {
+                    if let FfmpegOut::Progress { time, fps, .. } = progress? {
+                        bar.set_position(time.as_secs() + sample_idx * sample_duration_s * 2);
+                        if fps > 0.0 {
+                            bar.set_message(format!("enc {fps} fps,"));
+                        }
                     }
                 }
-                VmafOut::Progress(_) => {}
-                VmafOut::Err(e) => return Err(e),
+                let encode_time = b.elapsed();
+                let encoded_size = fs::metadata(&encoded_sample).await?.len();
+                let encoded_probe = ffprobe::probe(&encoded_sample);
+
+                // calculate vmaf
+                bar.set_message("vmaf running,");
+                let mut vmaf = vmaf::run(
+                    &sample,
+                    args.vfilter.as_deref(),
+                    &encoded_sample,
+                    &vmaf.ffmpeg_lavfi(encoded_probe.resolution),
+                    enc_args
+                        .pixel_format()
+                        .max(input_pixel_format.unwrap_or(PixelFormat::Yuv444p10le)),
+                )?;
+                let mut vmaf_score = -1.0;
+                while let Some(vmaf) = vmaf.next().await {
+                    match vmaf {
+                        VmafOut::Done(score) => {
+                            vmaf_score = score;
+                            break;
+                        }
+                        VmafOut::Progress(FfmpegOut::Progress { time, fps, .. }) => {
+                            bar.set_position(
+                                sample_duration_s
+                                    + time.as_secs()
+                                    + sample_idx * sample_duration_s * 2,
+                            );
+                            if fps > 0.0 {
+                                bar.set_message(format!("vmaf {fps} fps,"));
+                            }
+                        }
+                        VmafOut::Progress(_) => {}
+                        VmafOut::Err(e) => return Err(e),
+                    }
+                }
+
+                bar.println(
+                    style!(
+                        "- Sample {sample_n} ({:.0}%) vmaf {vmaf_score:.2}",
+                        100.0 * encoded_size as f32 / sample_size as f32
+                    )
+                    .dim()
+                    .to_string(),
+                );
+
+                let result = EncodeResult {
+                    vmaf_score,
+                    sample_size,
+                    encoded_size,
+                    encode_time,
+                    sample_duration: encoded_probe
+                        .duration
+                        .ok()
+                        .filter(|d| !d.is_zero())
+                        .unwrap_or(sample_duration),
+                    from_cache: false,
+                };
+
+                if let Some(k) = key {
+                    cache::cache_result(k, &result).await?;
+                }
+
+                // Early clean. Note: Avoid cleaning copy samples
+                temporary::clean(true).await;
+                if !keep {
+                    let _ = tokio::fs::remove_file(encoded_sample).await;
+                }
+
+                result
             }
-        }
+        };
 
-        bar.println(
-            style!(
-                "- Sample {sample_n} ({:.0}%) vmaf {vmaf_score:.2}",
-                100.0 * encoded_size as f32 / sample_size as f32
-            )
-            .dim()
-            .to_string(),
-        );
-
-        results.push(EncodeResult {
-            vmaf_score,
-            sample_size,
-            encoded_size,
-            encode_time,
-            sample_duration: encoded_probe
-                .duration
-                .ok()
-                .filter(|d| !d.is_zero())
-                .unwrap_or(sample_duration),
-        });
-
-        // Early clean. Note: Avoid cleaning copy samples
-        temporary::clean(true).await;
-        if !keep {
-            let _ = tokio::fs::remove_file(encoded_sample).await;
-        }
+        results.push(result);
     }
     bar.finish();
 
@@ -256,6 +300,7 @@ pub async fn run(
             .min(estimate_encode_size_by_file_percent(&results, &input, full_pass).await?),
         encode_percent: results.encoded_percent_size(),
         predicted_encode_time: results.estimate_encode_time(duration, full_pass),
+        from_cache: results.iter().all(|r| r.from_cache),
     };
 
     if !bar.is_hidden() {
@@ -276,12 +321,6 @@ pub async fn run(
     }
 
     Ok(output)
-}
-
-/// Use the entire video as a single sample
-async fn sample_full_pass(input: Arc<PathBuf>) -> anyhow::Result<(Arc<PathBuf>, u64)> {
-    let input_size = fs::metadata(&*input).await?.len();
-    Ok((input, input_size))
 }
 
 /// Copy a sample from the input to the temp_dir (or input dir).
@@ -311,7 +350,8 @@ async fn sample(
     Ok((sample.into(), sample_size))
 }
 
-struct EncodeResult {
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct EncodeResult {
     sample_size: u64,
     encoded_size: u64,
     vmaf_score: f32,
@@ -320,6 +360,8 @@ struct EncodeResult {
     ///
     /// This should be close to `SAMPLE_SIZE` but may deviate due to how samples are cut.
     sample_duration: Duration,
+    /// Result read from cache.
+    from_cache: bool,
 }
 
 trait EncodeResults {
@@ -476,4 +518,6 @@ pub struct Output {
     ///
     /// Sample encode time multiplied by duration.
     pub predicted_encode_time: Duration,
+    /// All sample results were read from the cache.
+    pub from_cache: bool,
 }

--- a/src/command/sample_encode/cache.rs
+++ b/src/command/sample_encode/cache.rs
@@ -1,0 +1,101 @@
+//! _sample-encode_ file system caching logic.
+use crate::command::args::EncoderArgs;
+use anyhow::Context;
+use std::{
+    ffi::OsStr,
+    hash::Hash,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tokio::fs;
+
+/// Return a previous stored encode result for the same sample & args.
+pub async fn cached_encode(
+    cache: bool,
+    sample: &Path,
+    input_duration: Duration,
+    input_extension: Option<&OsStr>,
+    input_size: u64,
+    enc_args: &EncoderArgs<'_>,
+) -> (Option<super::EncodeResult>, Option<Key>) {
+    if !cache {
+        return (None, None);
+    }
+
+    let hash = hash_encode(
+        // hashing the sample file name (which includes input name, frames & start)
+        // + input duration, extension & size should be reasonably unique for an input.
+        // and is much faster than hashing the entire file.
+        (
+            sample.file_name(),
+            input_duration,
+            input_extension,
+            input_size,
+        ),
+        enc_args,
+    );
+
+    let key = match Key::try_from_hash(hash) {
+        Ok(k) => k,
+        _ => return (None, None),
+    };
+
+    match fs::read(key.path())
+        .await
+        .ok()
+        .and_then(|d| serde_json::from_slice::<super::EncodeResult>(&d).ok())
+    {
+        Some(mut result) => {
+            result.from_cache = true;
+            (Some(result), Some(key))
+        }
+        _ => (None, Some(key)),
+    }
+}
+
+pub async fn cache_result(key: Key, result: &super::EncodeResult) -> anyhow::Result<()> {
+    let data = serde_json::to_vec(result)?;
+    let path = key.path();
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).await?;
+    }
+    fs::write(path, data).await?;
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct Key(PathBuf);
+
+impl Key {
+    fn try_from_hash(hash: blake3::Hash) -> anyhow::Result<Self> {
+        let mut path = dirs::cache_dir().context("no cache dir found")?;
+        path.push("ab-av1");
+        path.push(hash.to_hex().as_str());
+        path.set_extension("json");
+        Ok(Self(path))
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+fn hash_encode(input_info: impl Hash, enc_args: &EncoderArgs<'_>) -> blake3::Hash {
+    let mut hasher = blake3::Hasher::new();
+    let mut std_hasher = BlakeStdHasher(&mut hasher);
+    input_info.hash(&mut std_hasher);
+    enc_args.sample_encode_hash(&mut std_hasher);
+    hasher.finalize()
+}
+
+struct BlakeStdHasher<'a>(&'a mut blake3::Hasher);
+impl std::hash::Hasher for BlakeStdHasher<'_> {
+    fn finish(&self) -> u64 {
+        unimplemented!()
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.update(bytes);
+    }
+}

--- a/src/command/sample_encode/cache.rs
+++ b/src/command/sample_encode/cache.rs
@@ -10,6 +10,7 @@ pub async fn cached_encode(
     input_duration: Duration,
     input_extension: Option<&OsStr>,
     input_size: u64,
+    full_pass: bool,
     enc_args: &EncoderArgs<'_>,
 ) -> (Option<super::EncodeResult>, Option<Key>) {
     if !cache {
@@ -25,6 +26,7 @@ pub async fn cached_encode(
             input_duration,
             input_extension,
             input_size,
+            full_pass,
         ),
         enc_args,
     );

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -9,6 +9,7 @@ use crate::{
 use anyhow::Context;
 use std::{
     collections::HashSet,
+    hash::{Hash, Hasher},
     path::{Path, PathBuf},
     process::Stdio,
     sync::Arc,
@@ -27,6 +28,19 @@ pub struct FfmpegEncodeArgs<'a> {
     pub preset: Option<Arc<str>>,
     pub output_args: Vec<Arc<String>>,
     pub input_args: Vec<Arc<String>>,
+}
+
+impl FfmpegEncodeArgs<'_> {
+    pub fn sample_encode_hash(&self, state: &mut impl Hasher) {
+        // input not relevant to sample encoding
+        self.vcodec.hash(state);
+        self.vfilter.hash(state);
+        self.pix_fmt.hash(state);
+        self.crf.to_bits().hash(state);
+        self.preset.hash(state);
+        self.output_args.hash(state);
+        self.input_args.hash(state);
+    }
 }
 
 /// Encode a sample.

--- a/src/svtav1.rs
+++ b/src/svtav1.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use anyhow::Context;
 use std::{
+    hash::{Hash, Hasher},
     path::{Path, PathBuf},
     process::Stdio,
 };
@@ -27,6 +28,19 @@ pub struct SvtArgs<'a> {
     pub keyint: Option<i32>,
     pub scd: u8,
     pub args: Vec<&'a str>,
+}
+
+impl SvtArgs<'_> {
+    pub fn sample_encode_hash(&self, state: &mut impl Hasher) {
+        // input not relevant to sample encoding
+        self.vfilter.hash(state);
+        self.pix_fmt.hash(state);
+        self.crf.to_bits().hash(state);
+        self.preset.hash(state);
+        self.keyint.hash(state);
+        self.scd.hash(state);
+        self.args.hash(state);
+    }
 }
 
 /// Encode to sample ivf.


### PR DESCRIPTION
By default cache _sample-encode_ results in `$CACHE_DIR/ab-av1` directory using sled db.

Each result is keyed by `$RESULT_HASH`, computed using:
* sample file name
* input duration
* input extension
* input size
* encoder args
* `SvtAv1EncApp --version` (if applicable).

This mean they should be reasonably unique without requiring a full read of the input.

Caching _sample-encode_ results allows repeating runs of _crf-search_ perhaps with different `--min-vmaf` args etc. The cache will avoid the same crfs having to be re-encoded. 

If a _crf-search_ touches only pre-encoded crf values it'll finish pretty instantly.
```
$ ab-av1 crf-search -i test-vids/pixabay-lemon-82602.mp4 --preset 12 --min-vmaf 95
- crf 32 VMAF 95.87 (18%) (cached)
- crf 43 VMAF 92.08 (8%) (cached)
- crf 35 VMAF 94.95 (14%) (cached)
  00:00:00 ############################################### (sampling crf 34, eta 0s)
Encode with: ab-av1 encode -i test-vids/pixabay-lemon-82602.mp4 --crf 34 --preset 12

crf 34 VMAF 95.25 predicted video stream size 14.06 MiB (16%) taking 33 seconds
```

## Args
New `--cache true|false` arg is added for  _sample-encode_, _crf-search_ & _auto-encode_. Default it true. Can also be disabled by setting env var `AB_AV1_CACHE=false`

## Issues
~The `$RESULT_HASH` doesn't cover when an encoder has been upgraded to a new version. We could include `SvtAv1EncApp --version` output and possibly equivalent for other encoders.~ Also ffmpeg, though an upgrade shouldn't affect the result too much unless a bug had been related.

Update: I've now added the svt-av1 version to the $RESULT_HASH. Though x264 etc ffmpeg encoders are not included.

Included _sled_ db dependency has increased the binary size from ~1.6 -> 2.1 MiB. This seems worth it.

Resolves #59