### PR TITLE
Re-use best sample when encoding images

### DIFF
--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -10,7 +10,7 @@ use crate::{
 use clap::Parser;
 use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
-use std::{sync::Arc, time::Duration};
+use std::{fs, sync::Arc, time::Duration};
 
 /// Automatically determine the best crf to deliver the min-vmaf and use it to encode a video or image.
 ///
@@ -37,6 +37,9 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
     search.quiet = true;
     let defaulting_output = encode.output.is_none();
     let input_probe = Arc::new(ffprobe::probe(&search.args.input));
+
+    // Keep image samples so we can use the best sample as the final image
+    search.keep = input_probe.is_probably_an_image();
 
     let output = encode.output.unwrap_or_else(|| {
         default_output_name(
@@ -97,6 +100,21 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
         style(best.enc.vmaf).green(),
         style(format!("{:.0}%", best.enc.encode_percent)).green(),
     ));
+
+    // We don't need to do a final encode for images since we already did it when searching for the best CRF
+    if input_probe.is_probably_an_image() {
+        let output_path_with_best_crf = &output.with_extension(format!("crf{}.avif", best.crf()));
+
+        // Check if we actually have a real sample or if our best CRF was just read from the cache
+        if output_path_with_best_crf.exists() {
+            fs::rename(output_path_with_best_crf, output)?;
+            temporary::clean_all().await;
+            return Ok(());
+        }
+
+        // If the best CRF was read from the cache then we don't have an image to re-use, so we just continue as normal
+    }
+
     temporary::clean_all().await;
 
     let bar = ProgressBar::new(12).with_style(

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -80,6 +80,10 @@ pub struct Args {
 
     #[arg(skip)]
     pub quiet: bool,
+
+    /// Keep temporary files after exiting.
+    #[arg(long)]
+    pub keep: bool,
 }
 
 pub async fn crf_search(mut args: Args) -> anyhow::Result<()> {
@@ -123,6 +127,7 @@ pub async fn run(
         quiet,
         cache,
         vmaf,
+        keep
     }: &Args,
     input_probe: Arc<Ffprobe>,
     bar: ProgressBar,
@@ -142,7 +147,7 @@ pub async fn run(
         args: args.clone(),
         crf: 0.0,
         sample: sample.clone(),
-        keep: false,
+        keep: *keep,
         cache: *cache,
         stdout_format: sample_encode::StdoutFormat::Json,
         vmaf: vmaf.clone(),


### PR DESCRIPTION
Fixes #62 

This PR saves users from wasting time re-encoding the same image when an image with the best CRF has already been encoded.

I'm not entirely sure how the sample encode cache works, but I assume it doesn't store the samples themselves, so if the best CRF is read from the cache instead of being searched for then we still have to encode it again.

I'm leaving this as a draft for now because I'm not confident that `output_path_with_best_crf` (at `auto_encode.rs:106`) is done correctly. It works, but if the sample naming convention ever changes then this will break.