### PR TITLE
Add support for nvenc family of ffmpeg encoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   other encoders & allows svt-av1 encoding to benefit from more built-in ffmpeg behaviours like aspect preservation.<br/>
   **An ffmpeg build with libsvtav1 enabled is now required**. SvtAv1EncApp is no longer required.
 * Improve image detection.
+* Add `--encoder` support for nvenc family of ffmpeg encoders: av1_nvenc, hevc_nvenc, and h264_nvenc.
 
 # v0.6.1
 * Add _sample-encode_, _crf-search_, _auto-encode_ arg `--min-samples`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased (v0.7.0)
 * Use ffmpeg for svt-av1 encodes instead of invoking to SvtAv1EncApp directly. This unifies the handling of
-  other encoders & allows svt-av1 encoding to benefit from more built-in ffmpeg behaviours like aspect preservation.
+  other encoders & allows svt-av1 encoding to benefit from more built-in ffmpeg behaviours like aspect preservation.<br/>
+  **An ffmpeg build with libsvtav1 enabled is now required**. SvtAv1EncApp is no longer required.
 * Improve image detection.
 
 # v0.6.1

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -189,6 +189,9 @@ impl VCodecSpecific for Arc<str> {
         if self.ends_with("vaapi") {
             // Use -qp for vaapi codecs as crf is not supported
             "-qp"
+        } else if self.ends_with("nvenc") {
+            // Use -cq for nvenc codecs as crf is not supported
+            "-cq"
         } else {
             "-crf"
         }


### PR DESCRIPTION
The nvenc hardware encoders use -cq for target quality/vbr rate control.  Add the minimal arg logic to support this family of encoders.

This allows use of av1_nvenc, hevc_nvenc, and h264_nvenc.
```
C:\Video>ab-av1 auto-encode -i ToS-4k-1920.mov --encoder av1_nvenc
Encoding ToS-4k-1920.av1_nvenc.mkv
  Searching 00:00:47 #################################################################### (crf 39, VMAF 95.35, size 19%)
  Encoding  00:00:27 ################################################################################# (638 fps, eta 0s)
Encoded 128.97 MiB (18%, video:117.59 MiB, audio:11.05 MiB)
```

Additional features such as custom arguments are already supported.
```
C:\Video>ab-av1 crf-search -i ToS-4k-1920.mov --encoder av1_nvenc --preset p7 --enc rc-lookahead=32 --min-vmaf 96 --thorough --cache false
- crf 32 VMAF 98.28 (39%)
- crf 43 VMAF 92.59 (14%)
- crf 36 VMAF 96.99 (27%)
- crf 38 VMAF 96.07 (22%)
- crf 39 VMAF 95.51 (20%)
  00:01:06 ################################################################################### (sampling crf 39, eta 0s)
Encode with: ab-av1 encode -e av1_nvenc -i ToS-4k-1920.mov --crf 38 --preset p7 --enc rc-lookahead=32

crf 38 VMAF 96.07 predicted video stream size 157.32 MiB (22%) taking 61 seconds
```