### PR TITLE
Support concurrent running processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased (v0.7.2)
 * Preserve all input streams into outputs.
+* Support concurrent running processes out of the box by segregating temp-dirs & fixing cache access.
 
 # v0.7.1
 * Fix _crf-search_ incorrectly picking a rate that exceeds the `--max-encoded-percent`.

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -72,14 +72,14 @@ pub fn encode_sample(
 ) -> anyhow::Result<(PathBuf, impl Stream<Item = anyhow::Result<FfmpegOut>>)> {
     let pre = pre_extension_name(&vcodec);
     let crf_str = format!("{}", TerseF32(crf)).replace('.', "_");
-    let mut dest = match &preset {
+    let dest_file_name = match &preset {
         Some(p) => input.with_extension(format!("{pre}.crf{crf_str}.{p}.{dest_ext}")),
         None => input.with_extension(format!("{pre}.crf{crf_str}.{dest_ext}")),
     };
-    if let (Some(mut temp), Some(name)) = (temp_dir, dest.file_name()) {
-        temp.push(name);
-        dest = temp;
-    }
+    let dest_file_name = dest_file_name.file_name().unwrap();
+    let mut dest = temporary::process_dir(temp_dir, input);
+    dest.push(dest_file_name);
+
     temporary::add(&dest, TempKind::Keepable);
 
     let enc = Command::new("ffmpeg")

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod yuv;
 use anyhow::anyhow;
 use clap::Parser;
 use futures::FutureExt;
-use std::{io, time::Duration};
+use std::time::Duration;
 use tokio::signal;
 
 const SAMPLE_SIZE_S: u64 = 20;
@@ -33,7 +33,6 @@ enum Command {
 async fn main() -> anyhow::Result<()> {
     let action = Command::parse();
 
-    action.ensure_temp_dir_exists().await?;
     let keep = action.keep_temp_files();
 
     let local = tokio::task::LocalSet::new();
@@ -63,18 +62,5 @@ impl Command {
             Self::SampleEncode(args) => args.keep,
             _ => false,
         }
-    }
-
-    async fn ensure_temp_dir_exists(&self) -> io::Result<()> {
-        let temp_dir = match self {
-            Self::SampleEncode(args) => &args.sample.temp_dir,
-            Self::CrfSearch(args) => &args.sample.temp_dir,
-            Self::AutoEncode(args) => &args.search.sample.temp_dir,
-            _ => &None,
-        };
-        if let Some(dir) = temp_dir {
-            tokio::fs::create_dir_all(dir).await?;
-        }
-        Ok(())
     }
 }

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -20,13 +20,15 @@ pub async fn copy(
     frames: u32,
     temp_dir: Option<PathBuf>,
 ) -> anyhow::Result<PathBuf> {
+    let mut dest = temporary::process_dir(temp_dir, input);
     // Always using mkv for the samples works better than, e.g. using mp4 for mp4s
     // see https://github.com/alexheretic/ab-av1/issues/82#issuecomment-1337306325
-    let mut dest = input.with_extension(format!("sample{}+{frames}f.mkv", sample_start.as_secs()));
-    if let (Some(mut temp), Some(name)) = (temp_dir, dest.file_name()) {
-        temp.push(name);
-        dest = temp;
-    }
+    dest.push(
+        input
+            .with_extension(format!("sample{}+{frames}f.mkv", sample_start.as_secs()))
+            .file_name()
+            .unwrap(),
+    );
     if dest.exists() {
         return Ok(dest);
     }


### PR DESCRIPTION
Use segregated process-unique temp directory sub-dirs.
Add 2s blocking for cache locking.

Resolves #94 