### PR TITLE
Add QSV encoders support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Always copy audio unless `--acodec` or `--downmix-to-stereo` are specified. Previously would
   re-encode to opus when changing container.
 * Add `--encoder` support for qsv family of ffmpeg encoders: av1_qsv, hevc_qsv, vp9_qsv, h264_qsv and mpeg2_qsv.
-* Enable default look_ahead mode for encoders: av1_qsv, hevc_qsv, h264_qsv.
+* Enable default look_ahead=1, lookahead-depth=40 args for encoders: av1_qsv, hevc_qsv, h264_qsv.
 
 # v0.7.2
 * Print failing ffmpeg stderr output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Always copy audio unless `--acodec` or `--downmix-to-stereo` are specified. Previously would
   re-encode to opus when changing container.
 * Add `--encoder` support for qsv family of ffmpeg encoders: av1_qsv, hevc_qsv, vp9_qsv, h264_qsv and mpeg2_qsv.
+* Enable default look_ahead mode for encoders: av1_qsv, hevc_qsv, h264_qsv.
 
 # v0.7.2
 * Print failing ffmpeg stderr output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   settings as the main video stream.
 * Always copy audio unless `--acodec` or `--downmix-to-stereo` are specified. Previously would
   re-encode to opus when changing container.
+* Add `--encoder` support for qsv family of ffmpeg encoders: av1_qsv, hevc_qsv, vp9_qsv, h264_qsv and mpeg2_qsv.
 
 # v0.7.2
 * Print failing ffmpeg stderr output.

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -254,6 +254,16 @@ impl Encode {
             args.push("-b:v".to_owned().into());
             args.push("0".to_owned().into());
         }
+        
+        // add `-look_ahead 1 -lookahead-depth 40` for qsv encoders to use "lookahead" mode
+        if matches!(&*vcodec, "av1_qsv" | "hevc_qsv" | "h264_qsv")
+            && !args.iter().any(|arg| &**arg == "-look_ahead")
+        {
+            args.push("-look_ahead".to_owned().into());
+            args.push("1".to_owned().into());
+            args.push("-lookahead-depth".to_owned().into());
+            args.push("40".to_owned().into());
+        }
 
         let pix_fmt = self.pix_format.unwrap_or(match &*vcodec {
             vc if vc.contains("av1") => PixelFormat::Yuv420p10le,

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -261,6 +261,10 @@ impl Encode {
         {
             args.push("-look_ahead".to_owned().into());
             args.push("1".to_owned().into());
+        }
+        if matches!(&*vcodec, "av1_qsv" | "hevc_qsv" | "h264_qsv")
+            && !args.iter().any(|arg| &**arg == "-lookahead-depth")
+        {
             args.push("-lookahead-depth".to_owned().into());
             args.push("40".to_owned().into());
         }

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -247,26 +247,11 @@ impl Encode {
             }
         }
 
-        // add `-b:v 0` for aom & vp9 to use "constant quality" mode
-        if matches!(&*vcodec, "libaom-av1" | "libvpx-vp9")
-            && !args.iter().any(|arg| &**arg == "-b:v")
-        {
-            args.push("-b:v".to_owned().into());
-            args.push("0".to_owned().into());
-        }
-        
-        // add `-look_ahead 1 -lookahead-depth 40` for qsv encoders to use "lookahead" mode
-        if matches!(&*vcodec, "av1_qsv" | "hevc_qsv" | "h264_qsv")
-            && !args.iter().any(|arg| &**arg == "-look_ahead")
-        {
-            args.push("-look_ahead".to_owned().into());
-            args.push("1".to_owned().into());
-        }
-        if matches!(&*vcodec, "av1_qsv" | "hevc_qsv" | "h264_qsv")
-            && !args.iter().any(|arg| &**arg == "-lookahead-depth")
-        {
-            args.push("-lookahead-depth".to_owned().into());
-            args.push("40".to_owned().into());
+        for (name, val) in self.encoder.default_ffmpeg_args() {
+            if !args.iter().any(|arg| &**arg == name) {
+                args.push(name.to_string().into());
+                args.push(val.to_string().into());
+            }
         }
 
         let pix_fmt = self.pix_format.unwrap_or(match &*vcodec {
@@ -368,6 +353,19 @@ impl Encoder {
             "libx264" | "libx265" => 46.0,
             // Works well for svt-av1
             _ => 55.0,
+        }
+    }
+
+    /// Additional encoder specific ffmpeg arg defaults.
+    fn default_ffmpeg_args(&self) -> &[(&'static str, &'static str)] {
+        match self.as_str() {
+            // add `-b:v 0` for aom & vp9 to use "constant quality" mode
+            "libaom-av1" | "libvpx-vp9" => &[("-b:v", "0")],
+            // add `-look_ahead 1 -lookahead-depth 40` for qsv encoders to use "lookahead" mode
+            "av1_qsv" | "hevc_qsv" | "h264_qsv" => {
+                &[("-look_ahead", "1"), ("-lookahead-depth", "40")]
+            }
+            _ => &[],
         }
     }
 }

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -197,6 +197,9 @@ impl VCodecSpecific for Arc<str> {
         } else if self.ends_with("nvenc") {
             // Use -cq for nvenc codecs as crf is not supported
             "-cq"
+        } else if self.ends_with("qsv") {
+            // Use -global_quality for qsv codecs as crf is not supported
+            "-global_quality"
         } else {
             "-crf"
         }


### PR DESCRIPTION
A simple arg adding to support QSV encoders.

Maybe it would also be better to enable lookahead by default with HandBrake's default paramenters 
(-look_ahead 1 -lookahead-depth 40) 
https://handbrake.fr/docs/en/latest/technical/video-qsv.html