### PR TITLE
Fix args qsv look ahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased (v0.7.4)
 * Add `--encoder` support for qsv family of ffmpeg encoders: av1_qsv, hevc_qsv, vp9_qsv, h264_qsv and mpeg2_qsv.
-* Enable default look_ahead=1, lookahead-depth=40 args for encoders: av1_qsv, hevc_qsv, h264_qsv.
+* Enable lookahead mode by default for encoders: av1_qsv, hevc_qsv, h264_qsv.
 
 # v0.7.3
 * Include all other non-main video streams by copying instead of encoding them with the same

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -363,7 +363,7 @@ impl Encoder {
             "libaom-av1" | "libvpx-vp9" => &[("-b:v", "0")],
             // add `-look_ahead 1 -lookahead-depth 40` for qsv encoders to use "lookahead" mode
             "av1_qsv" | "hevc_qsv" | "h264_qsv" => {
-                &[("-look_ahead", "1"), ("--look_ahead_depth", "40")]
+                &[("-look_ahead", "1"), ("-extbrc", "1"), ("-look_ahead_depth", "40")]
             }
             _ => &[],
         }

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -361,10 +361,12 @@ impl Encoder {
         match self.as_str() {
             // add `-b:v 0` for aom & vp9 to use "constant quality" mode
             "libaom-av1" | "libvpx-vp9" => &[("-b:v", "0")],
-            // add `-look_ahead 1 -lookahead-depth 40` for qsv encoders to use "lookahead" mode
-            "av1_qsv" | "hevc_qsv" | "h264_qsv" => {
-                &[("-look_ahead", "1"), ("-extbrc", "1"), ("-look_ahead_depth", "40")]
-            }
+            // enable lookahead mode for qsv encoders
+            "av1_qsv" | "hevc_qsv" | "h264_qsv" => &[
+                ("-look_ahead", "1"),
+                ("-extbrc", "1"),
+                ("-look_ahead_depth", "40"),
+            ],
             _ => &[],
         }
     }

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -363,7 +363,7 @@ impl Encoder {
             "libaom-av1" | "libvpx-vp9" => &[("-b:v", "0")],
             // add `-look_ahead 1 -lookahead-depth 40` for qsv encoders to use "lookahead" mode
             "av1_qsv" | "hevc_qsv" | "h264_qsv" => {
-                &[("-look_ahead", "1"), ("-lookahead-depth", "40")]
+                &[("-look_ahead", "1"), ("--look_ahead_depth", "40")]
             }
             _ => &[],
         }


### PR DESCRIPTION
Actually in the HandBrake page I used to pick up the default value it uses the arg `-lookahead-depth`, but for ffmpeg it is `-look_ahead_depth <int>` which should also be enabled with the `extbrc` flag for encoders other than h264. (https://github.com/alexheretic/ab-av1/pull/121#issuecomment-1456032523)