### PR TITLE
Fix validation preventing use of --svt args starting with "-i"

### DIFF
--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -87,7 +87,7 @@ pub struct Encode {
 fn parse_svt_arg(arg: &str) -> anyhow::Result<Arc<str>> {
     let arg = arg.trim_start_matches('-').to_owned();
 
-    for deny in ["i", "b", "crf", "preset", "keyint", "scd", "input-depth"] {
+    for deny in ["b", "crf", "preset", "keyint", "scd", "input-depth"] {
         ensure!(!arg.starts_with(deny), "'{deny}' cannot be used here");
     }
 


### PR DESCRIPTION
Fix validation preventing use of --svt args starting with "-i", e.g. "-irefresh-type".