### PR TITLE
Hash VMAF args for cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Fix sample-encode caching to consider vmaf args.
+
 # v0.7.10
 * Fix validation preventing use of svt args starting with "-i", "-b".
 

--- a/src/command/args/vmaf.rs
+++ b/src/command/args/vmaf.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use std::{fmt::Display, sync::Arc, thread};
 
 /// Common vmaf options.
-#[derive(Parser, Clone)]
+#[derive(Parser, Clone, Hash)]
 pub struct Vmaf {
     /// Additional vmaf arg(s). E.g. --vmaf n_threads=8 --vmaf n_subsample=4
     ///

--- a/src/command/args/vmaf.rs
+++ b/src/command/args/vmaf.rs
@@ -34,6 +34,10 @@ fn parse_vmaf_arg(arg: &str) -> anyhow::Result<Arc<str>> {
 }
 
 impl Vmaf {
+    pub fn is_default(&self) -> bool {
+        self.vmaf_args.is_empty() && self.vmaf_scale == VmafScale::Auto
+    }
+
     /// Returns ffmpeg `filter_complex`/`lavfi` value for calculating vmaf.
     pub fn ffmpeg_lavfi(&self, distorted_res: Option<(u32, u32)>) -> String {
         let mut args = self.vmaf_args.clone();

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -168,7 +168,7 @@ pub async fn run(
             input_len,
             full_pass,
             &enc_args,
-            &vmaf
+            &vmaf,
         )
         .await
         {

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -168,6 +168,7 @@ pub async fn run(
             input_len,
             full_pass,
             &enc_args,
+            &vmaf
         )
         .await
         {

--- a/src/command/sample_encode/cache.rs
+++ b/src/command/sample_encode/cache.rs
@@ -102,13 +102,16 @@ pub struct Key(blake3::Hash);
 fn hash_encode(
     input_info: impl Hash,
     enc_args: &FfmpegEncodeArgs<'_>,
-    vmaf_args: &impl Hash,
+    vmaf_args: &Vmaf,
 ) -> blake3::Hash {
     let mut hasher = blake3::Hasher::new();
     let mut std_hasher = BlakeStdHasher(&mut hasher);
     input_info.hash(&mut std_hasher);
     enc_args.sample_encode_hash(&mut std_hasher);
-    vmaf_args.hash(&mut std_hasher);
+    if !vmaf_args.is_default() {
+        // avoid hashing if default for back compat
+        vmaf_args.hash(&mut std_hasher);
+    }
     hasher.finalize()
 }
 

--- a/src/command/sample_encode/cache.rs
+++ b/src/command/sample_encode/cache.rs
@@ -1,5 +1,5 @@
 //! _sample-encode_ file system caching logic.
-use crate::ffmpeg::FfmpegEncodeArgs;
+use crate::{command::args::Vmaf, ffmpeg::FfmpegEncodeArgs};
 use anyhow::Context;
 use std::{
     ffi::OsStr,
@@ -9,6 +9,7 @@ use std::{
 };
 
 /// Return a previous stored encode result for the same sample & args.
+#[allow(clippy::too_many_arguments)]
 pub async fn cached_encode(
     cache: bool,
     sample: &Path,
@@ -17,7 +18,7 @@ pub async fn cached_encode(
     input_size: u64,
     full_pass: bool,
     enc_args: &FfmpegEncodeArgs<'_>,
-    vmaf_args: &impl Hash,
+    vmaf_args: &Vmaf,
 ) -> (Option<super::EncodeResult>, Option<Key>) {
     if !cache {
         return (None, None);


### PR DESCRIPTION
Changing VMAF args such as `model`, `pool` - even resolution - results in different scores. These should therefor be included in the cache key.

Things still not reflected:
- Change in VMAF version
- Change in default model used by VMAF (because ab-av1 doesn't set it and I see no trivial way to detect it)
- Change in model used hardcoded by ab-av1 (if that changes, we still could invalidate all the hashes since it's very likely that none of the scores match anymore)