### PR TITLE
Add `--keep` flag to `crf-search` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 * Use a single ffmpeg process to calculate VMAF replacing multi process piping.
 * Exclude subtitle tracks from samples.
+* Add `--keep` option for _crf-search_.
 
 # v0.7.12
 * Improve eta stability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 * Use a single ffmpeg process to calculate VMAF replacing multi process piping.
 * Exclude subtitle tracks from samples.
-* Add `--keep` option for _crf-search_.
+* Add `--keep` option for _crf-search_ & _auto-encode_.
 
 # v0.7.12
 * Improve eta stability.

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -63,6 +63,10 @@ pub struct Sample {
     #[arg(long)]
     pub min_samples: Option<u64>,
 
+    /// Keep temporary files after exiting.
+    #[arg(long)]
+    pub keep: bool,
+
     /// Directory to store temporary sample data in.
     /// Defaults to using the input's directory.
     #[arg(long, env = "AB_AV1_TEMP_DIR")]

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -67,6 +67,11 @@ pub struct Args {
     #[arg(long)]
     pub crf_increment: Option<f32>,
 
+    // TODO refactor into Samples ArgGroup
+    /// Keep temporary files after exiting.
+    #[arg(long)]
+    pub keep: bool,
+
     /// Enable sample-encode caching.
     #[arg(
         long,
@@ -125,6 +130,7 @@ pub async fn run(
         thorough,
         sample,
         quiet,
+        keep,
         cache,
         vmaf,
     }: &Args,
@@ -146,7 +152,7 @@ pub async fn run(
         args: args.clone(),
         crf: 0.0,
         sample: sample.clone(),
-        keep: false,
+        keep: *keep,
         cache: *cache,
         stdout_format: sample_encode::StdoutFormat::Json,
         vmaf: vmaf.clone(),

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -67,11 +67,6 @@ pub struct Args {
     #[arg(long)]
     pub crf_increment: Option<f32>,
 
-    // TODO refactor into Samples ArgGroup
-    /// Keep temporary files after exiting.
-    #[arg(long)]
-    pub keep: bool,
-
     /// Enable sample-encode caching.
     #[arg(
         long,
@@ -130,7 +125,6 @@ pub async fn run(
         thorough,
         sample,
         quiet,
-        keep,
         cache,
         vmaf,
     }: &Args,
@@ -152,7 +146,6 @@ pub async fn run(
         args: args.clone(),
         crf: 0.0,
         sample: sample.clone(),
-        keep: *keep,
         cache: *cache,
         stdout_format: sample_encode::StdoutFormat::Json,
         vmaf: vmaf.clone(),

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -46,10 +46,6 @@ pub struct Args {
     #[clap(flatten)]
     pub sample: args::Sample,
 
-    /// Keep temporary files after exiting.
-    #[arg(long)]
-    pub keep: bool,
-
     /// Enable sample-encode caching.
     #[arg(
         long,
@@ -87,7 +83,6 @@ pub async fn run(
         args,
         crf,
         sample: sample_args,
-        keep,
         cache,
         stdout_format,
         vmaf,
@@ -103,6 +98,7 @@ pub async fn run(
     let duration = input_probe.duration.clone()?;
     let input_fps = input_probe.fps.clone()?;
     let samples = sample_args.sample_count(duration).max(1);
+    let keep = sample_args.keep;
     let temp_dir = sample_args.temp_dir;
 
     let (samples, sample_duration, full_pass) = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ impl Command {
     fn keep_temp_files(&self) -> bool {
         match self {
             Self::SampleEncode(args) => args.keep,
+            Self::CrfSearch(args) => args.keep,
             _ => false,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,22 +50,25 @@ async fn main() -> anyhow::Result<()> {
         _ = signal::ctrl_c() => Err(anyhow!("ctrl_c")),
     };
 
+    // Final cleanup. Samples are already deleted (if wished by the user) during `command::sample_encode::run`.
     temporary::clean(keep).await;
 
     out
 }
 
 impl Command {
-    // IMPORTANT: All clauses mentioned explicitly to enforce keeping this
-    // in sync with the list of commands that expose args::Sample.
+    /// This decides what commands will keep temp files.
+    ///
+    /// # Important
+    ///
+    /// Add commands using the sample sub-args here referencing the `keep` flag,
+    /// or the temp files will be removed anyways.
     fn keep_temp_files(&self) -> bool {
         match self {
             Self::SampleEncode(args) => args.sample.keep,
             Self::CrfSearch(args) => args.sample.keep,
             Self::AutoEncode(args) => args.search.sample.keep,
-            Self::Vmaf(_) => false,
-            Self::Encode(_) => false,
-            Self::PrintCompletions(_) => false,
+            _ => false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,11 +56,16 @@ async fn main() -> anyhow::Result<()> {
 }
 
 impl Command {
+    // IMPORTANT: All clauses mentioned explicitly to enforce keeping this
+    // in sync with the list of commands that expose args::Sample.
     fn keep_temp_files(&self) -> bool {
         match self {
-            Self::SampleEncode(args) => args.keep,
-            Self::CrfSearch(args) => args.keep,
-            _ => false,
+            Self::SampleEncode(args) => args.sample.keep,
+            Self::CrfSearch(args) => args.sample.keep,
+            Self::AutoEncode(args) => args.search.sample.keep,
+            Self::Vmaf(_) => false,
+            Self::Encode(_) => false,
+            Self::PrintCompletions(_) => false,
         }
     }
 }


### PR DESCRIPTION
For me it's very useful to look at the generated samples for manual verification. This command works on my machine right now.

@alexheretic please tell me if you want the flag refactored into `args::Sample`. Its probably better that way, right?