### PR TITLE
Enable cache access

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,6 @@
 pub mod args;
 pub mod auto_encode;
+pub mod cache;
 pub mod crf_search;
 pub mod encode;
 pub mod print_completions;
@@ -7,10 +8,12 @@ pub mod sample_encode;
 pub mod vmaf;
 
 pub use auto_encode::auto_encode;
+pub use cache::cache;
 pub use crf_search::crf_search;
 pub use encode::encode;
 pub use print_completions::print_completions;
 pub use sample_encode::sample_encode;
 pub use vmaf::vmaf;
 
+/// (filled, current, to do)
 const PROGRESS_CHARS: &str = "##-";

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -70,7 +70,7 @@ pub struct Sample {
 
     /// Extension preference for encoded samples (ffmpeg encoder only).
     #[arg(skip)]
-    pub extension: Option<Arc<str>>,
+    pub extension: Option<String>,
 }
 
 impl Sample {

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -66,7 +66,7 @@ pub struct Encode {
     ///
     /// See https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/svt-av1_encoder_user_guide.md#options
     #[arg(long = "svt", value_parser = parse_svt_arg)]
-    pub svt_args: Vec<Arc<str>>,
+    pub svt_args: Vec<String>,
 
     /// Additional ffmpeg encoder arg(s). E.g. `--enc x265-params=lossless=1`
     /// These are added as ffmpeg output file options.
@@ -84,7 +84,7 @@ pub struct Encode {
     pub enc_input_args: Vec<String>,
 }
 
-fn parse_svt_arg(arg: &str) -> anyhow::Result<Arc<str>> {
+fn parse_svt_arg(arg: &str) -> anyhow::Result<String> {
     let arg = arg.trim_start_matches('-').to_owned();
 
     for deny in ["crf", "preset", "keyint", "scd", "input-depth"] {
@@ -109,12 +109,8 @@ fn parse_enc_arg(arg: &str) -> anyhow::Result<String> {
 }
 
 impl Encode {
-    pub fn to_encoder_args(
-        &self,
-        crf: f32,
-        probe: &Ffprobe,
-    ) -> anyhow::Result<FfmpegEncodeArgs<'_>> {
-        self.to_ffmpeg_args(Arc::clone(&self.encoder.0), crf, probe)
+    pub fn to_encoder_args(&self, crf: f32, probe: &Ffprobe) -> anyhow::Result<FfmpegEncodeArgs> {
+        self.to_ffmpeg_args(self.encoder.0, crf, probe)
     }
 
     pub fn encode_hint(&self, crf: f32) -> String {
@@ -173,10 +169,10 @@ impl Encode {
 
     fn to_ffmpeg_args(
         &self,
-        vcodec: Arc<str>,
+        vcodec: String,
         crf: f32,
         probe: &Ffprobe,
-    ) -> anyhow::Result<FfmpegEncodeArgs<'_>> {
+    ) -> anyhow::Result<FfmpegEncodeArgs> {
         let svtav1 = &*vcodec == "libsvtav1";
         ensure!(
             svtav1 || self.svt_args.is_empty(),
@@ -203,7 +199,7 @@ impl Encode {
             svtav1_params.extend(self.svt_args.iter().map(|a| a.to_string()));
         }
 
-        let mut args: Vec<Arc<String>> = self
+        let mut args: Vec<String> = self
             .enc_args
             .iter()
             .flat_map(|arg| {
@@ -234,7 +230,7 @@ impl Encode {
         }
 
         for (name, val) in self.encoder.default_ffmpeg_args() {
-            if !args.iter().any(|arg| &**arg == name) {
+            if !args.iter().any(|arg| arg == name) {
                 args.push(name.to_string().into());
                 args.push(val.to_string().into());
             }
@@ -245,7 +241,7 @@ impl Encode {
             _ => PixelFormat::Yuv420p,
         });
 
-        let input_args: Vec<Arc<String>> = self
+        let input_args: Vec<String> = self
             .enc_input_args
             .iter()
             .flat_map(|arg| {
@@ -281,10 +277,10 @@ impl Encode {
         }
 
         Ok(FfmpegEncodeArgs {
-            input: &self.input,
+            input: self.input,
             vcodec,
             pix_fmt,
-            vfilter: self.vfilter.as_deref(),
+            vfilter: self.vfilter,
             crf,
             preset,
             output_args: args,
@@ -317,7 +313,7 @@ impl Encode {
 
 /// Video codec for encoding.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Encoder(Arc<str>);
+pub struct Encoder(String);
 
 impl Encoder {
     /// vcodec name that would work if you used it as the -e argument.
@@ -376,7 +372,7 @@ impl std::str::FromStr for Encoder {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Preset {
     Number(u8),
-    Name(Arc<str>),
+    Name(String),
 }
 
 impl fmt::Display for Preset {
@@ -564,7 +560,7 @@ fn svtav1_to_ffmpeg_args_default_over_3m() {
 
     assert_eq!(&*vcodec, "libsvtav1");
     assert_eq!(input, enc.input);
-    assert_eq!(vfilter, Some("scale=320:-1,fps=film"));
+    assert_eq!(vfilter, Some("scale=320:-1,fps=film".to_owned()));
     assert_eq!(crf, 32.0);
     assert_eq!(preset, Some("8".into()));
     assert_eq!(pix_fmt, PixelFormat::Yuv420p10le);

--- a/src/command/args/vmaf.rs
+++ b/src/command/args/vmaf.rs
@@ -11,7 +11,7 @@ pub struct Vmaf {
     ///
     /// Also see https://ffmpeg.org/ffmpeg-filters.html#libvmaf.
     #[arg(long = "vmaf", value_parser = parse_vmaf_arg)]
-    pub vmaf_args: Vec<Arc<str>>,
+    pub vmaf_args: Vec<String>,
 
     /// Video resolution scale to use in VMAF analysis. If set, video streams will be bicupic
     /// scaled to this width during VMAF analysis. `auto` (default) automatically sets
@@ -29,7 +29,7 @@ pub struct Vmaf {
     pub vmaf_scale: VmafScale,
 }
 
-fn parse_vmaf_arg(arg: &str) -> anyhow::Result<Arc<str>> {
+fn parse_vmaf_arg(arg: &str) -> anyhow::Result<String> {
     Ok(arg.to_owned().into())
 }
 
@@ -155,7 +155,7 @@ impl Default for VmafModel {
 }
 
 impl VmafModel {
-    fn from_args(args: &[Arc<str>]) -> Option<Self> {
+    fn from_args(args: &[String]) -> Option<Self> {
         let mut using_custom_model: Vec<_> = args.iter().filter(|v| v.contains("model")).collect();
 
         match using_custom_model.len() {

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -38,7 +38,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
 
     search.quiet = true;
     let defaulting_output = encode.output.is_none();
-    let input_probe = Arc::new(ffprobe::probe(&search.args.input));
+    let input_probe = ffprobe::probe(&search.args.input);
 
     let output = encode.output.unwrap_or_else(|| {
         default_output_name(

--- a/src/command/cache.rs
+++ b/src/command/cache.rs
@@ -1,0 +1,51 @@
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+use clap::{arg, Parser};
+
+use crate::ffmpeg::FfmpegEncodeArgs;
+#[derive(Parser)]
+#[clap(verbatim_doc_comment)]
+#[group(skip, multiple = false)]
+pub struct Args {
+    /// Reference video file.
+    #[arg(long)]
+    pub import: Option<PathBuf>,
+
+    /// Ffmpeg video filter applied to the reference before analysis.
+    /// E.g. --vfilter "scale=1280:-1,fps=24".
+    #[arg(long)]
+    pub export: Option<PathBuf>,
+}
+
+pub struct EncArgs {
+    ffmpeg: FfmpegEncodeArgs,
+}
+
+pub async fn cache(Args { import, export }: Args) -> anyhow::Result<()> {
+    match (import, export) {
+        (_, Some(export)) => {
+            let db = open_db();
+            Ok(())
+        }
+        (Some(import), _) => todo!(),
+        _ => unreachable!(),
+    }
+}
+
+pub fn open_db() -> sled::Result<sled::Db> {
+    const LOCK_MAX_WAIT: Duration = Duration::from_secs(2);
+
+    let mut path = dirs::cache_dir().expect("no cache dir found");
+    path.push("ab-av1");
+    path.push("sample-encode-cache");
+    let a = Instant::now();
+    let mut db = sled::open(&path);
+    while db.is_err() && a.elapsed() < LOCK_MAX_WAIT {
+        std::thread::yield_now();
+        db = sled::open(&path);
+    }
+    db
+}

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -128,7 +128,7 @@ pub async fn run(
         cache,
         vmaf,
     }: &Args,
-    input_probe: Arc<Ffprobe>,
+    input_probe: Ffprobe,
     bar: ProgressBar,
 ) -> Result<Sample, Error> {
     let max_crf = max_crf.unwrap_or_else(|| args.encoder.default_max_crf());

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -59,7 +59,7 @@ pub async fn run(
                 video_only,
             },
     }: Args,
-    probe: Arc<Ffprobe>,
+    probe: Ffprobe,
     bar: &ProgressBar,
 ) -> anyhow::Result<()> {
     let defaulting_output = output.is_none();

--- a/src/ffprobe.rs
+++ b/src/ffprobe.rs
@@ -3,6 +3,7 @@ use crate::command::args::PixelFormat;
 use anyhow::{anyhow, Context};
 use std::{fmt, fs::File, io::Read, path::Path, time::Duration};
 
+#[derive(Clone)]
 pub struct Ffprobe {
     /// Duration of video.
     pub duration: Result<Duration, ProbeError>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ enum Command {
     Encode(command::encode::Args),
     CrfSearch(command::crf_search::Args),
     AutoEncode(command::auto_encode::Args),
+    Cache(command::cache::Args),
     PrintCompletions(command::print_completions::Args),
 }
 
@@ -42,6 +43,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Encode(args) => command::encode(args).boxed_local(),
         Command::CrfSearch(args) => command::crf_search(args).boxed_local(),
         Command::AutoEncode(args) => command::auto_encode(args).boxed_local(),
+        Command::Cache(args) => command::cache(args).boxed_local(),
         Command::PrintCompletions(args) => return command::print_completions(args),
     });
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -297,9 +297,3 @@ impl_arg_string_display!(u16);
 impl_arg_string_display!(u32);
 impl_arg_string_display!(i32);
 impl_arg_string_display!(f32);
-
-impl ArgString for Arc<str> {
-    fn arg_string(&self) -> Cow<'_, OsStr> {
-        Cow::Borrowed((**self).as_ref())
-    }
-}


### PR DESCRIPTION
Hey,

I really want to be able to edit the cache. So I started refactoring a bit. Two things:

- As you can see, I started to replace the Arc<> with just clones of String and PathBuf. Usage was inconsistent over the files and it seems unnecessary. I assume you wanted to gain speed/save RAM? Copying FFmpeg Param struct even over like 20 samples and 10 CRF search runs should be negligible RAM usage compared to what the video encoder takes, and speed should also not nearly be a bottleneck to any use case. If anything, the whole thread-safe accessing over tokyo threads and mutex locking could make things slower, compared to cheap `memcpy`s (atleast thats my understanding). Would you be ok with me simplifying those structs?
- Can I ask why you use sled? Again, performance should not be an issue (a few ms lookup vs minutes to hours of encoding), and with JSON we have the possibility to
  1. edit the cache with text editors (deleting entries primarily),
  2. version it in GIT (if experimenting or discovering bugs), *and best of all*
  3. saving cleartext params instead of only hashes (so we can precisely look up past runs).
  
  Would you allow me to change the backend to JSON (or similar)? It would probably make things easier instead of maintaining two formats (and should also make development alot easier since you can just look at the runs directly).

I don't want to come of as criticizing, I'm sure you noticed I enjoy working with and on your program and design decisions in the start are hard if not impossible to get right :) so thanks again!