### PR TITLE
Use a single ffmpeg process to calculate VMAF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,15 @@ jobs:
     - run: cargo run --locked -- print-completions fish
     - run: cargo run --locked -- print-completions zsh
 
-  test-windows:
-    runs-on: windows-latest
-    env:
-      RUST_BACKTRACE: 1
-    steps:
-    - run: rustup update stable
-    - uses: actions/checkout@v4
-    - run: cargo check
+  # Disabled while we no longer need cfg(windows) code
+  # test-windows:
+  #   runs-on: windows-latest
+  #   env:
+  #     RUST_BACKTRACE: 1
+  #   steps:
+  #   - run: rustup update stable
+  #   - uses: actions/checkout@v4
+  #   - run: cargo check
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Use a single ffmpeg process to calculate VMAF replacing multi process piping.
+
 # v0.7.12
 * Improve eta stability.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,6 @@ dependencies = [
  "tokio",
  "tokio-process-stream",
  "tokio-stream",
- "unix-named-pipe",
 ]
 
 [[package]]
@@ -320,33 +319,12 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -753,7 +731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
  "bitflags 2.4.1",
- "errno 0.3.8",
+ "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
@@ -844,19 +822,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
-
-[[package]]
-name = "socket2"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
+checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
 
 [[package]]
 name = "strsim"
@@ -946,7 +914,6 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -1012,16 +979,6 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "unix-named-pipe"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad653da8f36ac5825ba06642b5a3cce14a4e52c6a5fab4a8928d53f4426dae2"
-dependencies = [
- "errno 0.2.8",
- "libc",
-]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,6 @@ tokio = { version = "1.15", features = ["rt", "macros", "process", "fs", "signal
 tokio-process-stream = "0.4"
 tokio-stream = "0.1"
 
-[target.'cfg(unix)'.dependencies]
-unix-named-pipe = "0.2"
-
-[target.'cfg(windows)'.dependencies.tokio]
-version = "1.15"
-features = ["net"]
-
 [profile.release]
 lto = true
 opt-level = "s"

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -214,12 +214,14 @@ pub async fn run(
                 bar.set_message("vmaf running,");
                 let mut vmaf = vmaf::run(
                     &sample,
-                    args.vfilter.as_deref(),
                     &encoded_sample,
-                    &vmaf.ffmpeg_lavfi(encoded_probe.resolution),
-                    enc_args
-                        .pix_fmt
-                        .max(input_pixel_format.unwrap_or(PixelFormat::Yuv444p10le)),
+                    &vmaf.ffmpeg_lavfi(
+                        encoded_probe.resolution,
+                        enc_args
+                            .pix_fmt
+                            .max(input_pixel_format.unwrap_or(PixelFormat::Yuv444p10le)),
+                        args.vfilter.as_deref(),
+                    ),
                 )?;
                 let mut vmaf_score = -1.0;
                 while let Some(vmaf) = vmaf.next().await {

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -29,7 +29,7 @@ pub struct Args {
     pub reference: PathBuf,
 
     /// Ffmpeg video filter applied to the reference before analysis.
-    /// E.g. --vfilter "scale=1280:-1,fps=24".
+    /// E.g. --reference-vfilter "scale=1280:-1,fps=24".
     #[arg(long)]
     pub reference_vfilter: Option<String>,
 
@@ -68,10 +68,12 @@ pub async fn vmaf(
 
     let mut vmaf = vmaf::run(
         &reference,
-        reference_vfilter.as_deref(),
         &distorted,
-        &vmaf.ffmpeg_lavfi(dprobe.resolution),
-        dpix_fmt.max(rpix_fmt),
+        &vmaf.ffmpeg_lavfi(
+            dprobe.resolution,
+            dpix_fmt.max(rpix_fmt),
+            reference_vfilter.as_deref(),
+        ),
     )?;
     let mut vmaf_score = -1.0;
     while let Some(vmaf) = vmaf.next().await {

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -1,8 +1,5 @@
 //! vmaf logic
-use crate::{
-    command::args::PixelFormat,
-    process::{exit_ok_stderr, Chunks, CommandExt, FfmpegOut},
-};
+use crate::process::{exit_ok_stderr, Chunks, CommandExt, FfmpegOut};
 use anyhow::Context;
 use std::path::Path;
 use tokio::process::Command;
@@ -13,39 +10,18 @@ use tokio_stream::{Stream, StreamExt};
 /// This can produce more accurate results than testing directly from original source.
 pub fn run(
     reference: &Path,
-    reference_vfilter: Option<&str>,
     distorted: &Path,
     filter_complex: &str,
-    pix_fmt: PixelFormat,
 ) -> anyhow::Result<impl Stream<Item = VmafOut>> {
-    // convert reference & distorted to yuv streams of the same pixel format
-    // frame rate and presentation timestamp to improve vmaf accuracy
-    let (yuv_out, yuv_pipe) = yuv::pipe(reference, pix_fmt, reference_vfilter)?;
-    let yuv_pipe = yuv_pipe.filter_map(VmafOut::ignore_ok);
-
-    #[cfg(unix)]
-    let (distorted_fifo, distorted_yuv_pipe) = yuv::unix::pipe_to_fifo(distorted, pix_fmt)?;
-    #[cfg(unix)]
-    let (distorted, yuv_pipe) = (
-        &distorted_fifo,
-        yuv_pipe.merge(distorted_yuv_pipe.filter_map(VmafOut::ignore_ok)),
-    );
-    #[cfg(windows)]
-    let (distorted_npipe, distorted_yuv_pipe) = yuv::windows::named_pipe(distorted, pix_fmt)?;
-    #[cfg(windows)]
-    let (distorted, yuv_pipe) = (
-        &distorted_npipe,
-        yuv_pipe.merge(distorted_yuv_pipe.filter_map(VmafOut::ignore_ok)),
-    );
-
     let vmaf: ProcessChunkStream = Command::new("ffmpeg")
         .kill_on_drop(true)
+        .arg2("-r", "24")
         .arg2("-i", distorted)
-        .arg2("-i", "-")
+        .arg2("-r", "24")
+        .arg2("-i", reference)
         .arg2("-filter_complex", filter_complex)
         .arg2("-f", "null")
         .arg("-")
-        .stdin(yuv_out)
         .try_into()
         .context("ffmpeg vmaf")?;
 
@@ -56,7 +32,7 @@ pub fn run(
         Item::Done(code) => VmafOut::ignore_ok(exit_ok_stderr("ffmpeg vmaf", code, &chunks)),
     });
 
-    Ok(yuv_pipe.merge(vmaf))
+    Ok(vmaf)
 }
 
 #[derive(Debug)]
@@ -87,148 +63,5 @@ impl VmafOut {
             return Some(Self::Progress(progress));
         }
         None
-    }
-}
-
-mod yuv {
-    use super::*;
-    use std::process::Stdio;
-
-    /// ffmpeg yuv4mpegpipe returning the stdout & [`FfmpegProgress`] stream.
-    pub fn pipe(
-        input: &Path,
-        pix_fmt: PixelFormat,
-        vfilter: Option<&str>,
-    ) -> anyhow::Result<(Stdio, impl Stream<Item = anyhow::Result<FfmpegOut>>)> {
-        // sync presentation timestamp
-        let vfilter: std::borrow::Cow<'_, str> = match vfilter {
-            None => "setpts=PTS-STARTPTS".into(),
-            Some(vf) if vf.contains("setpts=") => vf.into(),
-            Some(vf) => format!("{vf},setpts=PTS-STARTPTS").into(),
-        };
-
-        let mut yuv4mpegpipe = Command::new("ffmpeg")
-            .kill_on_drop(true)
-            // Use 24fps to match vmaf models
-            .arg2("-r", "24")
-            .arg2("-i", input)
-            .arg2("-pix_fmt", pix_fmt.as_str())
-            .arg2("-vf", vfilter.as_ref())
-            .arg2("-strict", "-1")
-            .arg2("-f", "yuv4mpegpipe")
-            .arg("-")
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .context("ffmpeg yuv4mpegpipe")?;
-        let stdout = yuv4mpegpipe.stdout.take().unwrap().try_into().unwrap();
-        let stream = FfmpegOut::stream(yuv4mpegpipe, "ffmpeg yuv4mpegpipe");
-        Ok((stdout, stream))
-    }
-
-    #[cfg(windows)]
-    pub mod windows {
-        use super::*;
-
-        pub fn named_pipe(
-            input: &Path,
-            pix_fmt: PixelFormat,
-        ) -> anyhow::Result<(String, impl Stream<Item = anyhow::Result<FfmpegOut>>)> {
-            let in_name = {
-                let mut n = String::from(r"\\.\pipe\ab-av1-in-");
-                n.extend(std::iter::repeat_with(fastrand::alphanumeric).take(12));
-                n
-            };
-
-            let in_server = tokio::net::windows::named_pipe::ServerOptions::new()
-                .access_outbound(false)
-                .first_pipe_instance(true)
-                .max_instances(1)
-                .create(&in_name)?;
-
-            let out_name = in_name.replacen("-in-", "-out-", 1);
-            let out_server = tokio::net::windows::named_pipe::ServerOptions::new()
-                .access_inbound(false)
-                .first_pipe_instance(true)
-                .max_instances(1)
-                .create(&out_name)?;
-
-            async fn copy_in_pipe_to_out(
-                mut in_pipe: tokio::net::windows::named_pipe::NamedPipeServer,
-                mut out_pipe: tokio::net::windows::named_pipe::NamedPipeServer,
-            ) -> tokio::io::Result<()> {
-                in_pipe.connect().await?;
-                in_pipe.readable().await?;
-                out_pipe.connect().await?;
-                out_pipe.writable().await?;
-                tokio::io::copy(&mut in_pipe, &mut out_pipe).await?;
-                Ok(())
-            }
-            tokio::spawn(async move {
-                if let Err(err) = copy_in_pipe_to_out(in_server, out_server).await {
-                    eprintln!("Error copy_in_pipe_to_out: {err}");
-                }
-            });
-
-            let yuv4mpegpipe = Command::new("ffmpeg")
-                .kill_on_drop(true)
-                .arg2("-r", "24")
-                .arg2("-i", input)
-                .arg2("-pix_fmt", pix_fmt.as_str())
-                .arg2("-vf", "setpts=PTS-STARTPTS")
-                .arg2("-strict", "-1")
-                .arg2("-f", "yuv4mpegpipe")
-                .arg("-y")
-                .arg(&in_name)
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::piped())
-                .spawn()
-                .context("ffmpeg yuv4mpegpipe")?;
-            let stream = FfmpegOut::stream(yuv4mpegpipe, "ffmpeg yuv4mpegpipe");
-
-            Ok((out_name, stream))
-        }
-    }
-
-    #[cfg(unix)]
-    pub mod unix {
-        use super::*;
-        use crate::temporary::{self, TempKind};
-        use std::path::PathBuf;
-
-        /// ffmpeg yuv4mpegpipe returning the temporary fifo path & [`FfmpegProgress`] stream.
-        pub fn pipe_to_fifo(
-            input: &Path,
-            pix_fmt: PixelFormat,
-        ) -> anyhow::Result<(PathBuf, impl Stream<Item = anyhow::Result<FfmpegOut>>)> {
-            let fifo = PathBuf::from(format!(
-                "/tmp/ab-av1-{}.fifo",
-                std::iter::repeat_with(fastrand::alphanumeric)
-                    .take(12)
-                    .collect::<String>()
-            ));
-            unix_named_pipe::create(&fifo, None)?;
-            temporary::add(&fifo, TempKind::NotKeepable);
-
-            let yuv4mpegpipe = Command::new("ffmpeg")
-                .kill_on_drop(true)
-                .arg2("-r", "24")
-                .arg2("-i", input)
-                .arg2("-pix_fmt", pix_fmt.as_str())
-                .arg2("-vf", "setpts=PTS-STARTPTS")
-                .arg2("-strict", "-1")
-                .arg2("-f", "yuv4mpegpipe")
-                .arg("-y")
-                .arg(&fifo)
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::piped())
-                .spawn()
-                .context("ffmpeg yuv4mpegpipe")?;
-            let stream = FfmpegOut::stream(yuv4mpegpipe, "ffmpeg yuv4mpegpipe");
-            Ok((fifo, stream))
-        }
     }
 }


### PR DESCRIPTION
Use a single ffmpeg process to calculate VMAF replacing multi process piping.

Previously separate ffmpeg processes were used to convert pixel format and to run --reference-vfilter. This PR changes this to a single ffmpeg call with appropriate `-filter_complex` args.

A simple vmaf call will now use -filter_complex something like:
```
[0:v]format=yuv420p10le,setpts=PTS-STARTPTS[dis];[1:v]format=yuv420p10le,setpts=PTS-STARTPTS[ref];[dis][ref]libvmaf=n_threads=16
```

This simplifies the code removing platform specific piping code. It also should make vmaf results easier to reproduce by users.