### PR TITLE
Add vmaf --cuda option

### DIFF
--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -222,6 +222,7 @@ pub async fn run(
                             .max(input_pixel_format.unwrap_or(PixelFormat::Yuv444p10le)),
                         args.vfilter.as_deref(),
                     ),
+                    false,
                 )?;
                 let mut vmaf_score = -1.0;
                 while let Some(vmaf) = vmaf.next().await {

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -12,11 +12,22 @@ pub fn run(
     reference: &Path,
     distorted: &Path,
     filter_complex: &str,
+    cuda: bool,
 ) -> anyhow::Result<impl Stream<Item = VmafOut>> {
+    if cuda {
+        eprintln!("\nDEBUG: Using ffmpeg -filter_complex {filter_complex}");
+    }
+
     let vmaf: ProcessChunkStream = Command::new("ffmpeg")
         .kill_on_drop(true)
+        .arg2_if(cuda, "-hwaccel", "cuda")
+        .arg2_if(cuda, "-hwaccel_output_format", "cuda")
+        .arg2_if(cuda, "-codec:v", "av1_cuvid") // TODO: determine this automatically?
         .arg2("-r", "24")
         .arg2("-i", distorted)
+        .arg2_if(cuda, "-hwaccel", "cuda")
+        .arg2_if(cuda, "-hwaccel_output_format", "cuda")
+        .arg2_if(cuda, "-codec:v", "av1_cuvid") // TODO: determine this automatically?
         .arg2("-r", "24")
         .arg2("-i", reference)
         .arg2("-filter_complex", filter_complex)


### PR DESCRIPTION
Add support for CUDA accelerated vmaf. 

Run vmaf command with arg `--cuda` to enable.

This is experimental/incomplete. I can't test this properly myself as I lack nvidia hardware.