### PR TITLE
Support logging via RUST_LOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 * Show full ffmpeg command after errors.
 * For *_vaapi encoders map `--crf` to ffmpeg `-q` (instead of `-qp`).
 * Set av1_vaapi default `--max-crf` to 255.
+* Fix sample-encode printing output to non-terminals.
+* Omit "Encode with: ..." stderr hint for non-terminals.
+* Support logging enable by setting env var `RUST_LOG`. E.g:
+  - `RUST_LOG=ab_av1=info` "info" level logs various progress results like sample encode info
+  - `RUST_LOG=ab_av1=debug` "debug" level logs include ffmpeg calls
 
 # v0.7.14
 * Fix bash completions of some filenames.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,14 @@ dependencies = [
  "clap_complete",
  "console",
  "dirs",
+ "env_logger",
  "fastrand",
  "ffprobe",
  "futures",
  "humantime",
  "indicatif",
  "infer",
+ "log",
  "serde",
  "serde_json",
  "shell-escape",
@@ -314,6 +316,28 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
 
 [[package]]
 name = "errno"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ clap = { version = "4", features = ["derive", "env", "wrap_help"] }
 clap_complete = "4.4.10"
 console = "0.15.4"
 dirs = "5"
+env_logger = { version = "0.11.3", default-features = false, features = ["auto-color", "humantime"] }
 fastrand = "2"
 ffprobe = "0.4"
 futures = "0.3.19"
 humantime = "2.1"
 indicatif = "0.17"
 infer = { version = "0.16", default-features = false }
+log = "0.4.21"
 serde = { version = "1.0.185", features = ["derive"] }
 serde_json = "1.0.105"
 shell-escape = "0.1.5"

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -102,12 +102,14 @@ pub async fn crf_search(mut args: Args) -> anyhow::Result<()> {
     bar.finish();
     let best = best?;
 
-    // encode how-to hint + predictions
-    eprintln!(
-        "\n{} {}\n",
-        style("Encode with:").dim(),
-        style(args.args.encode_hint(best.crf())).dim().italic(),
-    );
+    if std::io::stderr().is_terminal() {
+        // encode how-to hint + predictions
+        eprintln!(
+            "\n{} {}\n",
+            style("Encode with:").dim(),
+            style(args.args.encode_hint(best.crf())).dim().italic(),
+        );
+    }
 
     StdoutFormat::Human.print_result(&best, input_is_image);
 
@@ -169,6 +171,7 @@ pub async fn run(
             args.clone(),
             input_probe.clone(),
             sample_bar.clone(),
+            false,
         ));
 
         let sample_task = loop {

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -6,6 +6,7 @@ use crate::{
     temporary::{self, TempKind},
 };
 use anyhow::Context;
+use log::debug;
 use std::{
     collections::HashSet,
     hash::{Hash, Hasher},
@@ -102,6 +103,7 @@ pub fn encode_sample(
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
     let cmd_str = cmd.to_cmd_str();
+    debug!("cmd `{cmd_str}`");
 
     let enc = cmd.spawn().context("ffmpeg encode_sample")?;
 
@@ -171,6 +173,7 @@ pub fn encode(
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
     let cmd_str = cmd.to_cmd_str();
+    debug!("cmd `{cmd_str}`");
 
     let enc = cmd.spawn().context("ffmpeg encode")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ enum Command {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
+    env_logger::init();
     let action = Command::parse();
 
     let keep = action.keep_temp_files();

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -1,6 +1,7 @@
 //! vmaf logic
 use crate::process::{exit_ok_stderr, Chunks, CommandExt, FfmpegOut};
 use anyhow::Context;
+use log::debug;
 use std::path::Path;
 use tokio::process::Command;
 use tokio_process_stream::{Item, ProcessChunkStream};
@@ -24,6 +25,7 @@ pub fn run(
         .arg("-");
 
     let cmd_str = cmd.to_cmd_str();
+    debug!("cmd `{cmd_str}`");
     let vmaf: ProcessChunkStream = cmd.try_into().context("ffmpeg vmaf")?;
 
     let mut chunks = Chunks::default();


### PR DESCRIPTION
* Support logging enable by setting env var `RUST_LOG`. E.g:
  - `RUST_LOG=ab_av1=info` "info" level logs various progress results like sample encode info
  - `RUST_LOG=ab_av1=debug` "debug" level logs include ffmpeg calls
* Fix sample-encode printing output to non-terminals.
* Omit "Encode with: ..." stderr hint for non-terminals.