### PR TITLE
vmaf: Don't force input frame rate.

### DIFF
--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -22,9 +22,9 @@ pub fn run(
 
     let mut cmd = Command::new("ffmpeg");
     cmd.kill_on_drop(true)
-        .arg2("-r", "24")
+        // .arg2("-r", "24")
         .arg2("-i", distorted)
-        .arg2("-r", "24")
+        // .arg2("-r", "24")
         .arg2("-i", reference)
         .arg2("-filter_complex", filter_complex)
         .arg2("-f", "null")

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -22,9 +22,7 @@ pub fn run(
 
     let mut cmd = Command::new("ffmpeg");
     cmd.kill_on_drop(true)
-        // .arg2("-r", "24")
         .arg2("-i", distorted)
-        // .arg2("-r", "24")
         .arg2("-i", reference)
         .arg2("-filter_complex", filter_complex)
         .arg2("-f", "null")


### PR DESCRIPTION
Remove the input option `-r` from ffmpeg command and rely on PTS of the respective containers. Add `settb` filter to establish common timebase for different containers.

Different timestamp syncing:
Use the absolute nearest timestamp for frame selection in libvmaf. Also stop at the end of the shortest stream, which sometimes helps with n_subsample>1 when, for some reason, ffmpeg fails with no score to parse. Both options can be overridden by `--vmaf`.

In case the VMAF score obtained using this new approach are lower than expected, adding `--vmaf ts_sync_mode=default` should be tried.

This is supposed to address some issues (#108, #141) which, this author believes, are due to (periodic) de-synchronization of frames in libvmaf caused by rounding errors in the timestamp calculation. It should also now be possible to compare videos with different frame rates with the help of `--reference-vfilter=fps=<fps(distorted)>`, which is an actual use case as [@mr44er pointed out](https://github.com/alexheretic/ab-av1/issues/141#issuecomment-1751737537).