### PR TITLE
Add crf-search `-v` & auto-encode `-v`, `-vv` flag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   - Disable when using custom min/max crf ranges under half the default.
 * Add sample-encode info to crf-search & auto-encode. Show sample progress and encoding/vmaf fps.
 * Improve sample-encode progress format consistency.
+* Add crf-search `-v` flag to print per-sample results.
+* Add auto-encode `-v` flag to print per-crf results, `-vv` to also print per-sample results.
 
 # v0.7.19
 * Fix stdin handling sometimes breaking bash shells.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "async-stream",
  "blake3",
  "clap",
+ "clap-verbosity-flag",
  "clap_complete",
  "console",
  "dirs",
@@ -222,6 +223,16 @@ checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e099138e1807662ff75e2cebe4ae2287add879245574489f9b1588eb5e5564ed"
+dependencies = [
+ "clap",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.53"
 async-stream = "0.3.5"
 blake3 = "1.3.3"
 clap = { version = "4", features = ["derive", "env", "wrap_help"] }
+clap-verbosity-flag = "2.2.2"
 clap_complete = "4.4.10"
 console = "0.15.4"
 dirs = "5"


### PR DESCRIPTION
* Add crf-search `-v` flag to print per-sample results.
* Add auto-encode `-v` flag to print per-crf results, `-vv` to also print per-sample results.