### PR TITLE
Add `--vmaf-fps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased (0.8.1)
 * Support negative `--preset` args.
+* Add `--vmaf-fps`: Frame rate override used to analyse both reference & distorted videos.
 
 # v0.8.0
 * crf-search: Tweak 2nd iteration logic that slices the crf range at the 25% or 75% crf point.

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -294,6 +294,7 @@ pub fn run(
                                 .max(input_pixel_format.unwrap_or(PixelFormat::Yuv444p10le)),
                             args.vfilter.as_deref(),
                         ),
+                        vmaf.vmaf_fps,
                     )?;
                     let mut vmaf = pin!(vmaf);
                     let mut logger = ProgressLogger::new("ab_av1::vmaf", Instant::now());

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -74,6 +74,7 @@ pub async fn vmaf(
             dpix_fmt.max(rpix_fmt),
             vmaf.reference_vfilter.as_deref(),
         ),
+        vmaf.vmaf_fps,
     )?);
     let mut logger = ProgressLogger::new(module_path!(), Instant::now());
     let mut vmaf_score = None;

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -13,6 +13,7 @@ pub fn run(
     reference: &Path,
     distorted: &Path,
     filter_complex: &str,
+    fps: Option<f32>,
 ) -> anyhow::Result<impl Stream<Item = VmafOut>> {
     info!(
         "vmaf {} vs reference {}",
@@ -22,7 +23,9 @@ pub fn run(
 
     let mut cmd = Command::new("ffmpeg");
     cmd.kill_on_drop(true)
+        .arg2_opt("-r", fps)
         .arg2("-i", distorted)
+        .arg2_opt("-r", fps)
         .arg2("-i", reference)
         .arg2("-filter_complex", filter_complex)
         .arg2("-f", "null")


### PR DESCRIPTION
Allow setting vmaf fps, ie `-r` ffmpeg input arg for both reference & distorted inputs. 

Relates to #238