### PR TITLE
Add defaults for mpeg2video encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased (0.8.1)
 * Support negative `--preset` args.
 * Add `--vmaf-fps`: Frame rate override used to analyse both reference & distorted videos.
+* mpeg2video: map `--crf` to ffmpeg `-q` and set default crf range to 2-30.
 
 # v0.8.0
 * crf-search: Tweak 2nd iteration logic that slices the crf range at the 25% or 75% crf point.

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -341,11 +341,19 @@ impl Encoder {
         }
     }
 
+    pub fn default_min_crf(&self) -> f32 {
+        match self.as_str() {
+            "mpeg2video" => 2.0,
+            _ => 10.0,
+        }
+    }
+
     pub fn default_max_crf(&self) -> f32 {
         match self.as_str() {
             "libx264" | "libx265" => 46.0,
             "librav1e" => 255.0,
             "av1_vaapi" => 255.0,
+            "mpeg2video" => 30.0,
             // Works well for svt-av1
             _ => 55.0,
         }

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -204,10 +204,11 @@ impl VCodecSpecific for Arc<str> {
     }
 
     fn crf_arg(&self) -> &str {
-        // // use crf-like args to support encoders that don't have crf
+        // use crf-like args to support encoders that don't have crf
         match &**self {
             // https://ffmpeg.org//ffmpeg-codecs.html#librav1e
             "librav1e" => "-qp",
+            "mpeg2video" => "-q",
             // https://ffmpeg.org//ffmpeg-codecs.html#VAAPI-encoders
             e if e.ends_with("_vaapi") => "-q",
             e if e.ends_with("_nvenc") => "-cq",


### PR DESCRIPTION
mpeg2video: map `--crf` to ffmpeg `-q` and set default crf range to 2-30.

## Usage example
```
$ ab-av1 crf-search -i vid.mp4 -e mpeg2video --max-encoded-percent 300
- crf 16 VMAF 83.56 (84%) (cache)
- crf 8 VMAF 91.74 (143%) (cache)
- crf 2 VMAF 97.33 (485%) (cache)
- crf 5 VMAF 94.43 (209%) (cache)
  00:00:00 crf 4 1/1 ##################################################### (eta 0s)
Encode with: ab-av1 encode -e mpeg2video -i vid.mp4 --crf 4

crf 4 VMAF 95.61 predicted video stream size 52.16 MiB (259%) taking 1 second
```