### PR TITLE
Default `--vmaf-fps` to 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   - Add crf-search, auto-encode `--min-xpsnr` arg _(alternative to `--min-vmaf`)_.
   - Add `xpsnr` command for measuring XPSNR score.
 * Support negative `--preset` args.
-* Add `--vmaf-fps`: Frame rate override used to analyse both reference & distorted videos.
+* Add `--vmaf-fps`: Frame rate override used to analyse both reference & distorted videos. Default 25.
 * Omit data streams when outputting to matroska (.mkv or .webm).
 * mpeg2video: map `--crf` to ffmpeg `-q` and set default crf range to 2-30.
 

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -301,7 +301,7 @@ pub fn run(
                                         .max(input_pixel_format.unwrap_or(PixelFormat::Yuv444p10le)),
                                     score.reference_vfilter.as_deref().or(args.vfilter.as_deref()),
                                 ),
-                                vmaf.vmaf_fps,
+                                vmaf.fps(),
                             )?;
                             let mut vmaf = pin!(vmaf);
                             let mut logger = ProgressLogger::new("ab_av1::vmaf", Instant::now());

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -77,7 +77,7 @@ pub async fn vmaf(
             dpix_fmt.max(rpix_fmt),
             score.reference_vfilter.as_deref(),
         ),
-        vmaf.vmaf_fps,
+        vmaf.fps(),
     )?);
     let mut logger = ProgressLogger::new(module_path!(), Instant::now());
     let mut vmaf_score = None;


### PR DESCRIPTION
Default `-r 25` for reference & distorted inputs in all vmaf analysis. This can be disabled with `--vmaf-fps 0`.

Resolves #238