### PR TITLE
Omit audio, subtitle & data streams in VMAF calls to work around possible ffmpeg memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Support negative `--preset` args.
 * Add `--vmaf-fps`: Frame rate override used to analyse both reference & distorted videos. Default 25.
 * Omit data streams when outputting to matroska (.mkv or .webm).
+* Omit audio, subtitle & data streams in VMAF calls to work around possible ffmpeg memory leaks.
 * mpeg2video: map `--crf` to ffmpeg `-q` and set default crf range to 2-30.
 
 # v0.8.0

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -26,6 +26,11 @@ pub fn run(
         .arg2_opt("-r", fps)
         .arg2("-i", reference)
         .arg2("-filter_complex", filter_complex)
+        // Workaround unused streams causing ffmpeg memory leaks
+        // See https://github.com/alexheretic/ab-av1/issues/189
+        .arg("-an")
+        .arg("-sn")
+        .arg("-dn")
         .arg2("-f", "null")
         .arg("-")
         .stdin(Stdio::null());


### PR DESCRIPTION
Resolves #189