### PR TITLE
*_vulkan: use map crf to -qp, provide default input args for vulkan & vaapi encoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+* Encoder *_vaapi: Default args `--enc-input hwaccel=vaapi --enc-input hwaccel_output_format=vaapi`.
+* Encoder *_vulkan: Map `--crf` to ffmpeg `-qp`.
+* Encoder *_vulkan: Default args `--enc-input hwaccel=vulkan --enc-input hwaccel_output_format=vulkan`.
 * Encoder libvvenc: Map `--crf` to ffmpeg `-qp`.
 
 # v0.9.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blake3"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17679a8d69b6d7fd9cd9801a536cec9fa5e5970b69f9d4747f70b39b031f5e7"
+checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -219,9 +219,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "option-ext"
@@ -822,9 +822,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.9.0",
  "errno",

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -91,6 +91,12 @@ pub struct Encode {
     /// These are added as ffmpeg input file options.
     ///
     /// See --enc docs.
+    ///
+    /// For *_vaapi (e.g. h264_vaapi) encoders if none are provided defaults to:
+    /// `--enc-input hwaccel=vaapi --enc-input hwaccel_output_format=vaapi`.
+    ///
+    /// For *_vulkan encoders if none are provided defaults to:
+    /// `--enc-input hwaccel=vulkan --enc-input hwaccel_output_format=vulkan`.
     #[arg(long = "enc-input", allow_hyphen_values = true, value_parser = parse_enc_arg)]
     pub enc_input_args: Vec<String>,
 }
@@ -251,7 +257,7 @@ impl Encode {
             _ => PixelFormat::Yuv420p,
         });
 
-        let input_args: Vec<Arc<String>> = self
+        let mut input_args: Vec<Arc<String>> = self
             .enc_input_args
             .iter()
             .flat_map(|arg| {
@@ -262,6 +268,13 @@ impl Encode {
                 }
             })
             .collect();
+
+        for (name, val) in self.encoder.default_ffmpeg_input_args() {
+            if !input_args.iter().any(|arg| &**arg == name) {
+                input_args.push(name.to_string().into());
+                input_args.push(val.to_string().into());
+            }
+        }
 
         // ban usage of the bits we already set via other args & logic
         let reserved = HashMap::from([
@@ -352,9 +365,8 @@ impl Encoder {
 
     pub fn default_max_crf(&self) -> f32 {
         match self.as_str() {
+            "librav1e" | "av1_vaapi" => 255.0,
             "libx264" | "libx265" => 46.0,
-            "librav1e" => 255.0,
-            "av1_vaapi" => 255.0,
             "mpeg2video" => 30.0,
             // Works well for svt-av1
             _ => 55.0,
@@ -384,6 +396,19 @@ impl Encoder {
                 ("-look_ahead_depth", "40"),
             ],
             _ => &[],
+        }
+    }
+
+    /// Additional encoder specific ffmpeg input arg defaults.
+    fn default_ffmpeg_input_args(&self) -> &[(&'static str, &'static str)] {
+        match self.as_str() {
+            e if e.ends_with("_vaapi") => {
+                &[("-hwaccel", "vaapi"), ("-hwaccel_output_format", "vaapi")]
+            }
+            e if e.ends_with("_vulkan") => {
+                &[("-hwaccel", "vulkan"), ("-hwaccel_output_format", "vulkan")]
+            }
+            _ => <_>::default(),
         }
     }
 }

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -92,11 +92,10 @@ pub struct Encode {
     ///
     /// See --enc docs.
     ///
-    /// For *_vaapi (e.g. h264_vaapi) encoders if none are provided defaults to:
+    /// *_vaapi (e.g. h264_vaapi) encoder default:
     /// `--enc-input hwaccel=vaapi --enc-input hwaccel_output_format=vaapi`.
     ///
-    /// For *_vulkan encoders if none are provided defaults to:
-    /// `--enc-input hwaccel=vulkan --enc-input hwaccel_output_format=vulkan`.
+    /// *_vulkan encoder default: `--enc-input hwaccel=vulkan --enc-input hwaccel_output_format=vulkan`.
     #[arg(long = "enc-input", allow_hyphen_values = true, value_parser = parse_enc_arg)]
     pub enc_input_args: Vec<String>,
 }

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -221,6 +221,7 @@ impl VCodecSpecific for Arc<str> {
             "mpeg2video" => "-q",
             // https://ffmpeg.org//ffmpeg-codecs.html#VAAPI-encoders
             e if e.ends_with("_vaapi") => "-q",
+            e if e.ends_with("_vulkan") => "-qp",
             e if e.ends_with("_nvenc") => "-cq",
             // https://ffmpeg.org//ffmpeg-codecs.html#QSV-Encoders
             e if e.ends_with("_qsv") => "-global_quality",


### PR DESCRIPTION
* Encoder *_vaapi: Default args `--enc-input hwaccel=vaapi --enc-input hwaccel_output_format=vaapi`.
* Encoder *_vulkan: Map `--crf` to ffmpeg `-qp`.
* Encoder *_vulkan: Default args `--enc-input hwaccel=vulkan --enc-input hwaccel_output_format=vulkan`.

Resolves #294