### PR TITLE
Allow specifying ffmpeg decoder using `--enc-input c:v=CODEC`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * `--pix-format` no longer generally defaults to "yuv420p", instead if not specified no -pix_fmt 
   will be passed to ffmpeg allowing use of upstream defaults.
   However, libsvtav1, libaom-av1 & librav1e will continue to default to "yuv420p10le".
+* Allow specifying ffmpeg decoder using `--enc-input c:v=CODEC`.
 
 # v0.9.4
 * Encoder *_vaapi: Default args `--enc-input hwaccel=vaapi --enc-input hwaccel_output_format=vaapi`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blake3"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -219,9 +219,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -589,9 +589,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ad87c89110f55e4cd4dc2893a9790820206729eaf221555f742d540b0724a0"
+checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
 dependencies = [
  "jiff-static",
  "log",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d076d5b64a7e2fe6f0743f02c43ca4a6725c0f904203bfe276a5b3e793103605"
+checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -891,9 +891,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -276,26 +276,37 @@ impl Encode {
         }
 
         // ban usage of the bits we already set via other args & logic
-        let reserved = HashMap::from([
-            ("-c:a", " use --acodec"),
-            ("-codec:a", " use --acodec"),
-            ("-acodec", " use --acodec"),
+        let input_reserved = HashMap::from([
             ("-i", ""),
             ("-y", ""),
             ("-n", ""),
-            ("-c:v", " use --encoder"),
-            ("-c:v:0", " use --encoder"),
-            ("-codec:v", " use --encoder"),
-            ("-codec:v:0", " use --encoder"),
-            ("-vcodec", " use --encoder"),
             ("-pix_fmt", " use --pix-format"),
             ("-crf", ""),
             ("-preset", " use --preset"),
             ("-vf", " use --vfilter"),
             ("-filter:v", " use --vfilter"),
         ]);
-        for arg in args.iter().chain(input_args.iter()) {
-            if let Some(hint) = reserved.get(arg.as_str()) {
+        for arg in &input_args {
+            if let Some(hint) = input_reserved.get(arg.as_str()) {
+                anyhow::bail!("Encoder argument `{arg}` not allowed{hint}");
+            }
+        }
+        let output_reserved = {
+            let mut r = input_reserved;
+            r.extend([
+                ("-c:a", " use --acodec"),
+                ("-codec:a", " use --acodec"),
+                ("-acodec", " use --acodec"),
+                ("-c:v", " use --encoder"),
+                ("-c:v:0", " use --encoder"),
+                ("-codec:v", " use --encoder"),
+                ("-codec:v:0", " use --encoder"),
+                ("-vcodec", " use --encoder"),
+            ]);
+            r
+        };
+        for arg in &args {
+            if let Some(hint) = output_reserved.get(arg.as_str()) {
                 anyhow::bail!("Encoder argument `{arg}` not allowed{hint}");
             }
         }


### PR DESCRIPTION
Allow specifying ffmpeg decoder using `--enc-input c:v=CODEC`.

Resolves #300