### PR TITLE
Support omitting enc-input defaults for vaapi, vulkan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased (0.10.1)
+* Support setting `--enc-input hwaccel=none --enc-input hwaccel_output_format=none` to omit defaults
+  for *_vaapi, *_vulkan vcodecs introduced in v0.9.4.
+
 # v0.10.0
 * `--pix-format` no longer generally defaults to "yuv420p", instead if not specified no -pix_fmt 
   will be passed to ffmpeg allowing use of upstream defaults.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,9 +219,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -96,6 +96,9 @@ pub struct Encode {
     /// `--enc-input hwaccel=vaapi --enc-input hwaccel_output_format=vaapi`.
     ///
     /// *_vulkan encoder default: `--enc-input hwaccel=vulkan --enc-input hwaccel_output_format=vulkan`.
+    ///
+    /// Disable defaults by setting them to "none"
+    /// e.g. `-enc-input hwaccel=none --enc-input hwaccel_output_format=none`
     #[arg(long = "enc-input", allow_hyphen_values = true, value_parser = parse_enc_arg)]
     pub enc_input_args: Vec<String>,
 }
@@ -272,6 +275,16 @@ impl Encode {
             if !input_args.iter().any(|arg| &**arg == name) {
                 input_args.push(name.to_string().into());
                 input_args.push(val.to_string().into());
+            }
+        }
+
+        // support setting possibly default args as "none" to omit them
+        for (name, _) in self.encoder.default_ffmpeg_input_args() {
+            if let Some(idx) = input_args
+                .windows(2)
+                .position(|w| *w[0] == *name && *w[1] == "none")
+            {
+                input_args.splice(idx..idx + 2, []);
             }
         }
 


### PR DESCRIPTION
Support setting `--enc-input hwaccel=none --enc-input hwaccel_output_format=none` to omit defaults for *_vaapi, *_vulkan vcodecs introduced in v0.9.4.