### PR TITLE
Encode to tmp file, then overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Encode to a temporary file before renaming to the final destination to ensure atomicity and prevent partially encoded files.
 * Add crf-search `--stdout-format json` outputting newline delimited json messages,
   see [stdout-format-json.md](stdout-format-json.md).
 * Add `type`, `crf` & `from_cache` keys to the sample-encode `--stdout-format json` output.

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -15,9 +15,10 @@ use console::style;
 use indicatif::{HumanBytes, ProgressBar, ProgressStyle};
 use log::info;
 use std::{
+    ffi::OsString,
     path::{Path, PathBuf},
     sync::Arc,
-    time::{Duration, Instant},
+    time::{Duration, Instant}
 };
 use tokio::fs;
 use tokio_stream::StreamExt;
@@ -96,7 +97,9 @@ pub async fn run(
         output.file_name().and_then(|n| n.to_str()).unwrap_or("")
     );
 
-    let mut enc = ffmpeg::encode(enc_args, &output, has_audio, audio_codec, stereo_downmix)?;
+    let tmp_output = tmp_output_name(&output);
+
+    let mut enc = ffmpeg::encode(enc_args, &tmp_output, has_audio, audio_codec, stereo_downmix)?;
     let mut logger = ProgressLogger::new(module_path!(), Instant::now());
     let mut stream_sizes = None;
     while let Some(progress) = enc.next().await {
@@ -120,6 +123,8 @@ pub async fn run(
     }
     enc.wait().await?; // ensure process has exited
     bar.finish();
+
+    std::fs::rename(tmp_output, &output)?;
 
     // successful encode, so don't delete it!
     temporary::unadd(&output);
@@ -172,4 +177,17 @@ pub fn default_output_name(input: &Path, encoder: &Encoder, is_image: bool) -> P
     let pre = ffmpeg::pre_extension_name(encoder.as_str());
     let ext = default_output_ext(input, encoder, is_image);
     input.with_extension(format!("{pre}.{ext}"))
+}
+
+pub fn tmp_output_name(output: &Path) -> PathBuf {
+    let mut tmp_prefix = OsString::from(".tmp.ab-av1-encoding.");
+    let file_name = output
+        .file_name()
+        .expect("We couldn't have gotten this far if there was no name to refer to it by");
+
+    tmp_prefix.extend([file_name]);
+
+    let mut output = output.to_path_buf();
+    output.set_file_name(tmp_prefix);
+    output
 }

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -18,7 +18,7 @@ use std::{
     ffi::OsString,
     path::{Path, PathBuf},
     sync::Arc,
-    time::{Duration, Instant}
+    time::{Duration, Instant},
 };
 use tokio::fs;
 use tokio_stream::StreamExt;
@@ -99,7 +99,13 @@ pub async fn run(
 
     let tmp_output = tmp_output_name(&output);
 
-    let mut enc = ffmpeg::encode(enc_args, &tmp_output, has_audio, audio_codec, stereo_downmix)?;
+    let mut enc = ffmpeg::encode(
+        enc_args,
+        &tmp_output,
+        has_audio,
+        audio_codec,
+        stereo_downmix,
+    )?;
     let mut logger = ProgressLogger::new(module_path!(), Instant::now());
     let mut stream_sizes = None;
     while let Some(progress) = enc.next().await {

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -10,6 +10,7 @@ use crate::{
     process::FfmpegOut,
     temporary::{self, TempKind},
 };
+use anyhow::Context;
 use clap::Parser;
 use console::style;
 use indicatif::{HumanBytes, ProgressBar, ProgressStyle};
@@ -77,9 +78,6 @@ pub async fn run(
          Pass in `--overwrite-input` to allow this."
     );
 
-    // output is temporary until encoding has completed successfully
-    temporary::add(&output, TempKind::NotKeepable);
-
     if defaulting_output {
         let out = shell_escape::escape(output.display().to_string().into());
         bar.println(style!("Encoding {out}").dim().to_string());
@@ -105,7 +103,8 @@ pub async fn run(
         output.file_name().and_then(|n| n.to_str()).unwrap_or("")
     );
 
-    let tmp_output = tmp_output_name(&output);
+    let tmp_output = tmp_output_name(&output)?;
+    temporary::add(&tmp_output, TempKind::NotKeepable);
 
     let mut enc = ffmpeg::encode(
         enc_args,
@@ -138,10 +137,8 @@ pub async fn run(
     enc.wait().await?; // ensure process has exited
     bar.finish();
 
-    std::fs::rename(tmp_output, &output)?;
-
-    // successful encode, so don't delete it!
-    temporary::unadd(&output);
+    std::fs::rename(&tmp_output, &output)?;
+    temporary::unadd(&tmp_output);
 
     // print output info
     let output_size = fs::metadata(&output).await?.len();
@@ -193,15 +190,10 @@ pub fn default_output_name(input: &Path, encoder: &Encoder, is_image: bool) -> P
     input.with_extension(format!("{pre}.{ext}"))
 }
 
-pub fn tmp_output_name(output: &Path) -> PathBuf {
+pub fn tmp_output_name(output: &Path) -> anyhow::Result<PathBuf> {
     let mut tmp_prefix = OsString::from(".tmp.ab-av1-encoding.");
-    let file_name = output
-        .file_name()
-        .expect("We couldn't have gotten this far if there was no name to refer to it by");
-
-    tmp_prefix.extend([file_name]);
-
+    tmp_prefix.push(output.file_name().context("no output file name")?);
     let mut output = output.to_path_buf();
     output.set_file_name(tmp_prefix);
-    output
+    Ok(output)
 }


### PR DESCRIPTION
Basically what the title says. This will encode each one to a tmp file, then overwrite it once it's done. This serves two purposes:

1. Ensure that, if the process get interrupted, we don't end up with a half-encoded file that seems to be complete
2. Prevent the process from accidentally corrupting the input file if it's the same as the output file (as ffmpeg doesn't like that and corrupts it sometimes)