### PR TITLE
Don't allow overwriting by default, require special flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased (v0.11.0)
+* Disallow having `--input` the same as `--output` as this can lead to unintended data loss.
+  This may be explicitly overridden by passing `--overwrite-input`.
+
 # v0.10.1
 * Support setting `--enc-input hwaccel=none --enc-input hwaccel_output_format=none` to omit defaults
   for *_vaapi, *_vulkan vcodecs introduced in v0.9.4.

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -42,10 +42,10 @@ pub struct EncodeToOutput {
     #[arg(long)]
     pub video_only: bool,
 
-    /// By default, ab-av1 will not overwrite the input file (to prevent accidental data loss). If
-    /// you pass in this flag, ab-av1 will allow you to overwrite the input file.
-    #[arg(long, default_value_t = false)]
-    pub allow_overwrite: bool,
+    /// By default input files will not be overwritten to prevent accidental data loss.
+    /// Setting this option overrides that allowing input overwrites.
+    #[arg(long)]
+    pub overwrite_input: bool,
 }
 
 /// Sampling arguments.

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -52,6 +52,13 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
             input_probe.is_image,
         )
     });
+
+    anyhow::ensure!(
+        encode.overwrite_input || output != search.args.input,
+        "Input and Output are specified as the same file. Not proceeding. \
+         Pass in `--overwrite-input` to allow this."
+    );
+
     search.sample.set_extension_from_output(&output);
 
     let bar = ProgressBar::new(BAR_LEN).with_style(

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -10,7 +10,6 @@ use crate::{
     process::FfmpegOut,
     temporary::{self, TempKind},
 };
-use anyhow::bail;
 use clap::Parser;
 use console::style;
 use indicatif::{HumanBytes, ProgressBar, ProgressStyle};
@@ -60,25 +59,22 @@ pub async fn run(
                 audio_codec,
                 downmix_to_stereo,
                 video_only,
-                allow_overwrite,
+                overwrite_input,
             },
     }: Args,
     probe: Arc<Ffprobe>,
     bar: &ProgressBar,
 ) -> anyhow::Result<()> {
-    if !allow_overwrite && output.as_ref().is_some_and(|o| o == &args.input) {
-        bail!(
-            "
-Input and Output are specified as the same file, but `allow_overwrite` was false. Not proceeding.
-Pass in `--allow-overwrite` to allow this.
-        "
-        )
-    }
-
     let defaulting_output = output.is_none();
-    // let probe = ffprobe::probe(&args.input);
     let output =
         output.unwrap_or_else(|| default_output_name(&args.input, &args.encoder, probe.is_image));
+
+    anyhow::ensure!(
+        overwrite_input || output != args.input,
+        "Input and Output are specified as the same file. Not proceeding. \
+         Pass in `--overwrite-input` to allow this."
+    );
+
     // output is temporary until encoding has completed successfully
     temporary::add(&output, TempKind::NotKeepable);
 


### PR DESCRIPTION
Supercedes #179, basically just does what it says. Requires special flag to overwrite the original file.