### PR TITLE
Added support for hevc_videotoolbox

### DIFF
--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -382,6 +382,9 @@ impl Encoder {
     pub fn default_min_crf(&self) -> f32 {
         match self.as_str() {
             "mpeg2video" => 2.0,
+            // Negative values indicate inverted scale (higher abs value = better quality)
+            // For hevc_videotoolbox: -100 means CRF 100 (best quality)
+            "hevc_videotoolbox" => -100.0,
             _ => 10.0,
         }
     }
@@ -391,6 +394,9 @@ impl Encoder {
             "librav1e" | "av1_vaapi" => 255.0,
             "libx264" | "libx265" => 46.0,
             "mpeg2video" => 30.0,
+            // Negative values indicate inverted scale (higher abs value = better quality)
+            // For hevc_videotoolbox: -1 means CRF 1 (worst quality)
+            "hevc_videotoolbox" => -10.0,
             // Works well for svt-av1
             _ => 55.0,
         }

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -74,7 +74,7 @@ pub fn encode_sample(
     dest_ext: &str,
 ) -> anyhow::Result<(PathBuf, FfmpegOutStream)> {
     let pre = pre_extension_name(&vcodec);
-    let crf_str = format!("{}", TerseF32(crf)).replace('.', "_");
+    let crf_str = format!("{}", TerseF32(crf.abs())).replace('.', "_");
     let dest_file_name = match &preset {
         Some(p) => input.with_extension(format!("{pre}.crf{crf_str}.{p}.{dest_ext}")),
         None => input.with_extension(format!("{pre}.crf{crf_str}.{dest_ext}")),
@@ -92,7 +92,7 @@ pub fn encode_sample(
         .arg2("-i", input)
         .arg2("-c:v", &*vcodec)
         .args(output_args.iter().map(|a| &**a))
-        .arg2(vcodec.crf_arg(), crf)
+        .arg2(vcodec.crf_arg(), crf.abs())
         .arg2_opt("-pix_fmt", pix_fmt.map(|v| v.as_str()))
         .arg2_opt(vcodec.preset_arg(), preset)
         .arg2_opt("-vf", vfilter)
@@ -149,8 +149,9 @@ pub fn encode(
     };
     // This doesn't seem to work on .mp4 files
     let mut metadata = format!(
-        "AB_AV1_FFMPEG_ARGS=-c:v {vcodec} {} {crf}",
-        vcodec.crf_arg()
+        "AB_AV1_FFMPEG_ARGS=-c:v {vcodec} {} {}",
+        vcodec.crf_arg(),
+        crf.abs()
     );
     if let Some(preset) = &preset {
         write!(&mut metadata, " {} {preset}", vcodec.preset_arg()).unwrap();
@@ -168,7 +169,7 @@ pub fn encode(
         .arg2("-c:a", audio_codec)
         .arg2("-c:s", "copy")
         .args(output_args.iter().map(|a| &**a))
-        .arg2(vcodec.crf_arg(), crf)
+        .arg2(vcodec.crf_arg(), crf.abs())
         .arg2_opt("-pix_fmt", pix_fmt.map(|v| v.as_str()))
         .arg2_opt(vcodec.preset_arg(), preset)
         .arg2_opt("-vf", vfilter)


### PR DESCRIPTION
Besides having a different command line option, VideoToolbox uses an inverted scale, where higher values are better quality.  I tried to implement it with as few changes as possible.  The only thing I'm not happy with is that the user has to add a negative sign to their `--{max,min}-crf` flags for inverted scales.  I couldn't think of a succinct way to put that in the help strings without being more confusing than it's worth.  I think a flag like `--inverted-crf` would be a better user-facing solution, but I was minimizing the disturbances.  But I'd be happy to implement it if you think there's value in it.

I'm a beginner at Rust, so I used Claude to help me with the syntax and to write the tests, but the design is all mine.  Another reason I tried to limit my changes. 😬

<details>
<summary>Before</summary>

```
ab-av1 crf-search --keyint 3s --scd true --max-encoded-percent 100 --min-vmaf 90 -e hevc_videotoolbox -i test.mp4
- crf 32 VMAF 98.28 (315%)
- crf 46 VMAF 98.28 (315%)
- crf 55 VMAF 98.28 (315%)
Error: Failed to find a suitable crf
```
</details>

<details>
<summary>After</summary>

```
ab-av1 crf-search --keyint 3s --scd true --max-encoded-percent 100 --min-vmaf 93 -e hevc_videotoolbox -i colin-from-accounts.mkv
- crf 55 VMAF 93.72 (32%)
- crf 28 VMAF 78.97 (8%)
- crf 54 VMAF 93.41 (29%)
  00:01:28 crf 53 3/3 ############################################################################################################################################################# (eta 0s)
Encode with: ab-av1 encode -e hevc_videotoolbox -i colin-from-accounts.mkv --crf 53 --keyint 3s --scd true

crf 53 VMAF 93.41 predicted video stream size 540.84 MiB (29%) taking 2 minutes
```