### PR TITLE
Add vmaf --cuda option

### DIFF
--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -306,6 +306,8 @@ pub fn run(
                                     score.reference_vfilter.as_deref().or(args.vfilter.as_deref()),
                                 ),
                                 vmaf.fps(),
+                                vmaf.cuda,
+                                vmaf.cuda_hwaccel.unwrap_or(vmaf.cuda),
                             )?;
                             let mut vmaf = pin!(vmaf);
                             let mut logger = ProgressLogger::new("ab_av1::vmaf", Instant::now());

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -76,6 +76,8 @@ pub async fn vmaf(
             score.reference_vfilter.as_deref(),
         ),
         vmaf.fps(),
+        vmaf.cuda,
+        vmaf.cuda_hwaccel.unwrap_or(vmaf.cuda),
     )?);
     let mut logger = ProgressLogger::new(module_path!(), Instant::now());
     let mut vmaf_score = None;

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -13,6 +13,8 @@ pub fn run(
     distorted: &Path,
     filter_complex: &str,
     fps: Option<f32>,
+    cuda: bool,
+    cuda_hwaccel: bool,
 ) -> anyhow::Result<impl Stream<Item = VmafOut> + use<>> {
     info!(
         "vmaf {} vs reference {}",
@@ -22,9 +24,13 @@ pub fn run(
 
     let mut cmd = Command::new("ffmpeg");
     cmd.kill_on_drop(true)
+        .arg2_if(cuda && cuda_hwaccel, "-hwaccel", "cuda")
+        .arg2_if(cuda && cuda_hwaccel, "-hwaccel_output_format", "cuda")
         .arg2_opt("-r", fps)
         .arg2("-i", distorted)
         .arg2_opt("-r", fps)
+        .arg2_if(cuda && cuda_hwaccel, "-hwaccel", "cuda")
+        .arg2_if(cuda && cuda_hwaccel, "-hwaccel_output_format", "cuda")
         .arg2("-i", reference)
         .arg2("-filter_complex", filter_complex)
         // Workaround unused streams causing ffmpeg memory leaks


### PR DESCRIPTION
Adds support for CUDA accelerated vmaf, see: #163, #178, #320

Changes: 
- I added both a `--cuda` argument, which enables the feature and a `--cuda-hwaccel` argument that allows one to disable hardware decoding which would otherwise be used. 
The rationale is that hardware decoders may not support the target codec; as an example my GTX 1660s cannot decode av1 media.
- I added some tests to ensure that the filter chains get built correctly when using the new flags. I also manually tested multiple combinations across different files and everything seems to work as expected.

Notes: 
- I thought it was cleaner to extend the logic inside the `ffmpeg_lavfi` function instead of creating a new one. The logic remains the same and only a few strings differ, this avoids unnecessary duplication.
- When cuda is set to true, `scale_cuda` is always presesnt among the filters, even when scaling is not needed. That's to force conversion to `yuv420p` as it's the only format that works with `vmaf_cuda`, as tested in [#163](https://github.com/alexheretic/ab-av1/issues/163#issuecomment-3538868447)