### PR TITLE
Add `--log-interval` option for encode & auto-encode

### DIFF
--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -5,7 +5,7 @@ mod vmaf;
 pub use encode::*;
 pub use vmaf::*;
 
-use crate::{command::encode::default_output_ext, ffprobe::Ffprobe};
+use crate::{command::encode::default_output_ext, ffprobe::Ffprobe, log::LogInterval};
 use clap::{Parser, ValueHint};
 use std::{
     path::{Path, PathBuf},
@@ -141,4 +141,15 @@ impl std::hash::Hash for Xpsnr {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.xpsnr_fps.to_ne_bytes().hash(state);
     }
+}
+
+/// Progress logging arguments.
+#[derive(Debug, Parser, Clone, Default)]
+pub struct ProgressLog {
+    /// Interval between progress log messages when running non-interactively.
+    /// Accepts duration (e.g., "30s", "1m") or percentage (e.g., "2%").
+    /// Default: exponentially increasing intervals (16s, 32s, 64s, ...).
+    /// Not used during crf-search sampling.
+    #[arg(long, env = "AB_AV1_LOG_INTERVAL")]
+    pub log_interval: Option<LogInterval>,
 }

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -7,6 +7,7 @@ use crate::{
     console_ext::style,
     ffprobe,
     float::TerseF32,
+    log::LogInterval,
     temporary,
 };
 use anyhow::Context;
@@ -36,9 +37,20 @@ pub struct Args {
 
     #[clap(flatten)]
     pub encode: args::EncodeToOutput,
+
+    /// Interval between progress log messages when running non-interactively.
+    /// Accepts duration (e.g., "30s", "1m") or percentage (e.g., "2%").
+    #[arg(long)]
+    pub log_interval: Option<LogInterval>,
 }
 
-pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()> {
+pub async fn auto_encode(
+    Args {
+        mut search,
+        encode,
+        log_interval,
+    }: Args,
+) -> anyhow::Result<()> {
     const SPINNER_RUNNING: &str = "{spinner:.cyan.bold} {elapsed_precise:.bold} {prefix} {wide_bar:.cyan/blue} ({msg}eta {eta})";
     const SPINNER_FINISHED: &str =
         "{spinner:.cyan.bold} {elapsed_precise:.bold} {prefix} {wide_bar:.cyan/blue} ({msg})";
@@ -186,6 +198,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
                 output: Some(output),
                 ..encode
             },
+            log_interval,
         },
         input_probe,
         &bar,

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -7,7 +7,6 @@ use crate::{
     console_ext::style,
     ffprobe,
     float::TerseF32,
-    log::LogInterval,
     temporary,
 };
 use anyhow::Context;
@@ -38,17 +37,15 @@ pub struct Args {
     #[clap(flatten)]
     pub encode: args::EncodeToOutput,
 
-    /// Interval between progress log messages when running non-interactively.
-    /// Accepts duration (e.g., "30s", "1m") or percentage (e.g., "2%").
-    #[arg(long)]
-    pub log_interval: Option<LogInterval>,
+    #[clap(flatten)]
+    pub progress: args::ProgressLog,
 }
 
 pub async fn auto_encode(
     Args {
         mut search,
         encode,
-        log_interval,
+        progress,
     }: Args,
 ) -> anyhow::Result<()> {
     const SPINNER_RUNNING: &str = "{spinner:.cyan.bold} {elapsed_precise:.bold} {prefix} {wide_bar:.cyan/blue} ({msg}eta {eta})";
@@ -198,7 +195,7 @@ pub async fn auto_encode(
                 output: Some(output),
                 ..encode
             },
-            log_interval,
+            progress,
         },
         input_probe,
         &bar,

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -6,7 +6,7 @@ use crate::{
     console_ext::style,
     ffmpeg,
     ffprobe::{self, Ffprobe},
-    log::{LogInterval, ProgressLogger},
+    log::ProgressLogger,
     process::FfmpegOut,
     temporary::{self, TempKind},
 };
@@ -37,10 +37,8 @@ pub struct Args {
     #[clap(flatten)]
     pub encode: args::EncodeToOutput,
 
-    /// Interval between progress log messages when running non-interactively.
-    /// Accepts duration (e.g., "30s", "1m") or percentage (e.g., "2%").
-    #[arg(long)]
-    pub log_interval: Option<LogInterval>,
+    #[clap(flatten)]
+    pub progress: args::ProgressLog,
 }
 
 pub async fn encode(args: Args) -> anyhow::Result<()> {
@@ -67,7 +65,7 @@ pub async fn run(
                 video_only,
                 overwrite_input,
             },
-        log_interval,
+        progress: args::ProgressLog { log_interval },
     }: Args,
     probe: Arc<Ffprobe>,
     bar: &ProgressBar,

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -258,7 +258,7 @@ pub fn run(
                 }
                 (None, key) => {
                     let b = Instant::now();
-                    let mut logger = ProgressLogger::new(module_path!(), b);
+                    let mut logger = ProgressLogger::new(module_path!(), b, None);
                     let (encoded_sample, mut output) = ffmpeg::encode_sample(
                         FfmpegEncodeArgs {
                             input: &sample,
@@ -308,7 +308,7 @@ pub fn run(
                                 vmaf.fps(),
                             )?;
                             let mut vmaf = pin!(vmaf);
-                            let mut logger = ProgressLogger::new("ab_av1::vmaf", Instant::now());
+                            let mut logger = ProgressLogger::new("ab_av1::vmaf", Instant::now(), None);
                             let mut vmaf_score = None;
                             while let Some(vmaf) = vmaf.next().await {
                                 match vmaf {
@@ -364,7 +364,7 @@ pub fn run(
                             );
                             let xpsnr_out = xpsnr::run(&sample, &encoded_sample, &lavfi, xpsnr_opts.fps())?;
                             let mut xpsnr_out = pin!(xpsnr_out);
-                            let mut logger = ProgressLogger::new("ab_av1::xpsnr", Instant::now());
+                            let mut logger = ProgressLogger::new("ab_av1::xpsnr", Instant::now(), None);
                             let mut score = None;
                             while let Some(next) = xpsnr_out.next().await {
                                 match next {

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -41,6 +41,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub score: args::ScoreArgs,
+
+    #[clap(flatten)]
+    pub progress: args::ProgressLog,
 }
 
 pub async fn vmaf(
@@ -49,6 +52,7 @@ pub async fn vmaf(
         distorted,
         vmaf,
         score,
+        progress: args::ProgressLog { log_interval },
     }: Args,
 ) -> anyhow::Result<()> {
     let bar = ProgressBar::new(1).with_style(
@@ -77,7 +81,7 @@ pub async fn vmaf(
         ),
         vmaf.fps(),
     )?);
-    let mut logger = ProgressLogger::new(module_path!(), Instant::now(), None);
+    let mut logger = ProgressLogger::new(module_path!(), Instant::now(), log_interval);
     let mut vmaf_score = None;
     while let Some(vmaf) = vmaf.next().await {
         match vmaf {

--- a/src/command/vmaf.rs
+++ b/src/command/vmaf.rs
@@ -77,7 +77,7 @@ pub async fn vmaf(
         ),
         vmaf.fps(),
     )?);
-    let mut logger = ProgressLogger::new(module_path!(), Instant::now());
+    let mut logger = ProgressLogger::new(module_path!(), Instant::now(), None);
     let mut vmaf_score = None;
     while let Some(vmaf) = vmaf.next().await {
         match vmaf {

--- a/src/command/xpsnr.rs
+++ b/src/command/xpsnr.rs
@@ -36,6 +36,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub xpsnr: args::Xpsnr,
+
+    #[clap(flatten)]
+    pub progress: args::ProgressLog,
 }
 
 pub async fn xpsnr(
@@ -44,6 +47,7 @@ pub async fn xpsnr(
         distorted,
         score,
         xpsnr,
+        progress: args::ProgressLog { log_interval },
     }: Args,
 ) -> anyhow::Result<()> {
     let bar = ProgressBar::new(1).with_style(
@@ -71,7 +75,7 @@ pub async fn xpsnr(
         &lavfi(score.reference_vfilter.as_deref()),
         xpsnr.fps(),
     )?);
-    let mut logger = ProgressLogger::new(module_path!(), Instant::now(), None);
+    let mut logger = ProgressLogger::new(module_path!(), Instant::now(), log_interval);
     let mut score = None;
     while let Some(next) = xpsnr_out.next().await {
         match next {

--- a/src/command/xpsnr.rs
+++ b/src/command/xpsnr.rs
@@ -71,7 +71,7 @@ pub async fn xpsnr(
         &lavfi(score.reference_vfilter.as_deref()),
         xpsnr.fps(),
     )?);
-    let mut logger = ProgressLogger::new(module_path!(), Instant::now());
+    let mut logger = ProgressLogger::new(module_path!(), Instant::now(), None);
     let mut score = None;
     while let Some(next) = xpsnr_out.next().await {
         match next {

--- a/src/log.rs
+++ b/src/log.rs
@@ -34,11 +34,9 @@ impl std::str::FromStr for LogInterval {
             ensure!(!d.is_zero(), "interval must be greater than 0");
             return Ok(Self::Duration(d));
         }
-        let secs: u64 = s
-            .parse()
-            .map_err(|_| anyhow::anyhow!("invalid interval: {s}"))?;
-        ensure!(secs > 0, "interval must be greater than 0");
-        Ok(Self::Duration(Duration::from_secs(secs)))
+        anyhow::bail!(
+            "invalid interval '{s}': expected duration (e.g., '30s', '1m') or percentage (e.g., '5%')"
+        );
     }
 }
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,21 +1,74 @@
+use anyhow::ensure;
 use indicatif::HumanDuration;
 use log::{Level, info, log_enabled};
-use std::time::{Duration, Instant};
+use std::{
+    fmt,
+    time::{Duration, Instant},
+};
+
+/// Interval between progress log messages when running non-interactively.
+#[derive(Debug, Clone, Copy)]
+pub enum LogInterval {
+    /// Fixed duration between log messages.
+    Duration(Duration),
+    /// Fixed percentage of total progress between log messages.
+    Percent(f32),
+}
+
+impl std::str::FromStr for LogInterval {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        if let Some(pct) = s.strip_suffix('%') {
+            let val: f32 = pct
+                .trim()
+                .parse()
+                .map_err(|_| anyhow::anyhow!("invalid percentage: {s}"))?;
+            ensure!(
+                val > 0.0 && val <= 100.0,
+                "percentage must be between 0 and 100"
+            );
+            return Ok(Self::Percent(val));
+        }
+        if let Ok(d) = humantime::parse_duration(s) {
+            ensure!(!d.is_zero(), "interval must be greater than 0");
+            return Ok(Self::Duration(d));
+        }
+        let secs: u64 = s
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid interval: {s}"))?;
+        ensure!(secs > 0, "interval must be greater than 0");
+        Ok(Self::Duration(Duration::from_secs(secs)))
+    }
+}
+
+impl fmt::Display for LogInterval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Duration(d) => write!(f, "{}", humantime::format_duration(*d)),
+            Self::Percent(p) => write!(f, "{p}%"),
+        }
+    }
+}
 
 /// Struct that info logs progress messages on a stream action like encoding.
 #[derive(Debug)]
 pub struct ProgressLogger {
     target: &'static str,
     start: Instant,
+    interval: Option<LogInterval>,
     log_count: u32,
+    last_log_percent: f32,
 }
 
 impl ProgressLogger {
-    pub fn new(target: &'static str, start: Instant) -> Self {
+    pub fn new(target: &'static str, start: Instant, interval: Option<LogInterval>) -> Self {
         Self {
             target,
             start,
+            interval,
             log_count: 0,
+            last_log_percent: 0.0,
         }
     }
 
@@ -27,16 +80,11 @@ impl ProgressLogger {
         if log_enabled!(Level::Info) && completed > Duration::ZERO {
             let done = completed.as_secs_f64() / total.as_secs_f64();
 
-            let elapsed = self.start.elapsed();
-
-            let before_count = self.log_count;
-            while elapsed > self.next_log() {
-                self.log_count += 1;
-            }
-            if before_count == self.log_count {
+            if !self.should_log(done) {
                 return;
             }
 
+            let elapsed = self.start.elapsed();
             let eta = Duration::from_secs_f64(elapsed.as_secs_f64() / done).saturating_sub(elapsed);
             info!(
                 target: self.target,
@@ -47,8 +95,46 @@ impl ProgressLogger {
         }
     }
 
+    fn should_log(&mut self, done: f64) -> bool {
+        match self.interval {
+            None => self.should_log_exponential(),
+            Some(LogInterval::Duration(interval)) => self.should_log_duration(interval),
+            Some(LogInterval::Percent(pct)) => self.should_log_percent(done, pct),
+        }
+    }
+
+    fn should_log_exponential(&mut self) -> bool {
+        let elapsed = self.start.elapsed();
+        let before_count = self.log_count;
+        while elapsed > self.next_log_exponential() {
+            self.log_count += 1;
+        }
+        before_count != self.log_count
+    }
+
+    fn should_log_duration(&mut self, interval: Duration) -> bool {
+        let elapsed = self.start.elapsed();
+        let expected_count = (elapsed.as_secs_f64() / interval.as_secs_f64()) as u32;
+        if expected_count > self.log_count {
+            self.log_count = expected_count;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn should_log_percent(&mut self, done: f64, interval_pct: f32) -> bool {
+        let current_pct = (done * 100.0) as f32;
+        if current_pct >= self.last_log_percent + interval_pct {
+            self.last_log_percent = (current_pct / interval_pct).floor() * interval_pct;
+            true
+        } else {
+            false
+        }
+    }
+
     /// First log after >=16s, then >=32s etc
-    fn next_log(&self) -> Duration {
+    fn next_log_exponential(&self) -> Duration {
         Duration::from_secs(2_u64.pow(self.log_count + 4))
     }
 }


### PR DESCRIPTION
Add `--log-interval` option to control progress logging frequency when running non-interactively (stderr not a TTY).

  Accepts:
  - Duration: `--log-interval 30s`
  - Percentage: `--log-interval 2%`

  Default behavior (exponential backoff) unchanged when flag is omitted.

  The current exponential backoff (16s, 32s, 64s, 128s...) creates very long gaps for large encodes, making it difficult for wrapper applications to provide responsive progress feedback.


Passes linting, automated tests, and I built a windows .exe and ran it successfully multiple times without issue with my project.

Thanks for the project, Alex, it's been such a joy building a wrapper around it. 