### PR TITLE
Add JSON output support to crf-search

### DIFF
--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -85,7 +85,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
     while let Some(update) = crf_search.next().await {
         match update {
             Err(err) => {
-                if let crf_search::Error::NoGoodCrf { last } = &err {
+                if let crf_search::Error::NoGoodCrf { last, .. } = &err {
                     // show last sample attempt in progress bar
                     bar.set_style(
                         ProgressStyle::default_bar()

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -373,42 +373,7 @@ pub struct Sample {
 
 impl Sample {
     pub fn print_attempt(&self, bar: &ProgressBar, min_score: f32, max_encoded_percent: f32) {
-        if bar.is_hidden() {
-            info!(
-                "crf {} {} {:.2} ({:.0}%){}",
-                TerseF32(self.crf),
-                self.enc.score_kind,
-                self.enc.score,
-                self.enc.encode_percent,
-                if self.enc.from_cache { " (cache)" } else { "" }
-            );
-            return;
-        }
-
-        let crf_label = style("- crf").dim();
-        let mut crf = style(TerseF32(self.crf));
-        let vmaf_label = style(self.enc.score_kind).dim();
-        let mut vmaf = style(self.enc.score);
-        let mut percent = style!("{:.0}%", self.enc.encode_percent);
-        let open = style("(").dim();
-        let close = style(")").dim();
-        let cache_msg = match self.enc.from_cache {
-            true => style(" (cache)").dim(),
-            false => style(""),
-        };
-
-        if self.enc.score < min_score {
-            crf = crf.red().bright();
-            vmaf = vmaf.red().bright();
-        }
-        if self.enc.encode_percent > max_encoded_percent as _ {
-            crf = crf.red().bright();
-            percent = percent.red().bright();
-        }
-
-        bar.println(format!(
-            "{crf_label} {crf} {vmaf_label} {vmaf:.2} {open}{percent}{close}{cache_msg}"
-        ));
+        StdoutFormat::Human.print_attempt(self, bar, min_score, max_encoded_percent);
     }
 }
 
@@ -435,6 +400,59 @@ impl StdoutFormat {
                 println!(
                     "crf {crf} {score_kind} {score:.2} predicted {enc_description} size {size} ({percent}) taking {time}"
                 );
+            }
+        }
+    }
+
+    pub fn print_attempt(
+        self,
+        sample: &Sample,
+        bar: &ProgressBar,
+        min_score: f32,
+        max_encoded_percent: f32,
+    ) {
+        match self {
+            Self::Human => {
+                if bar.is_hidden() {
+                    info!(
+                        "crf {} {} {:.2} ({:.0}%){}",
+                        TerseF32(sample.crf),
+                        sample.enc.score_kind,
+                        sample.enc.score,
+                        sample.enc.encode_percent,
+                        if sample.enc.from_cache {
+                            " (cache)"
+                        } else {
+                            ""
+                        }
+                    );
+                    return;
+                }
+
+                let crf_label = style("- crf").dim();
+                let mut crf = style(TerseF32(sample.crf));
+                let vmaf_label = style(sample.enc.score_kind).dim();
+                let mut vmaf = style(sample.enc.score);
+                let mut percent = style!("{:.0}%", sample.enc.encode_percent);
+                let open = style("(").dim();
+                let close = style(")").dim();
+                let cache_msg = match sample.enc.from_cache {
+                    true => style(" (cache)").dim(),
+                    false => style(""),
+                };
+
+                if sample.enc.score < min_score {
+                    crf = crf.red().bright();
+                    vmaf = vmaf.red().bright();
+                }
+                if sample.enc.encode_percent > max_encoded_percent as _ {
+                    crf = crf.red().bright();
+                    percent = percent.red().bright();
+                }
+
+                bar.println(format!(
+                    "{crf_label} {crf} {vmaf_label} {vmaf:.2} {open}{percent}{close}{cache_msg}"
+                ));
             }
         }
     }

--- a/src/command/crf_search/err.rs
+++ b/src/command/crf_search/err.rs
@@ -1,9 +1,16 @@
 use crate::command::crf_search::Sample;
+use crate::command::sample_encode::ScoreKind;
+use crate::float::TerseF32;
 use std::fmt;
 
 #[derive(Debug)]
 pub enum Error {
-    NoGoodCrf { last: Sample },
+    NoGoodCrf {
+        last: Sample,
+        min_score: f32,
+        max_encoded_percent: f32,
+        score_kind: ScoreKind,
+    },
     Other(anyhow::Error),
 }
 
@@ -15,9 +22,20 @@ impl Error {
         Ok(())
     }
 
-    pub fn ensure_or_no_good_crf(condition: bool, last: &Sample) -> Result<(), Self> {
+    pub fn ensure_or_no_good_crf(
+        condition: bool,
+        last: &Sample,
+        min_score: f32,
+        max_encoded_percent: f32,
+        score_kind: ScoreKind,
+    ) -> Result<(), Self> {
         if !condition {
-            return Err(Self::NoGoodCrf { last: last.clone() });
+            return Err(Self::NoGoodCrf {
+                last: last.clone(),
+                min_score,
+                max_encoded_percent,
+                score_kind,
+            });
         }
         Ok(())
     }
@@ -38,7 +56,35 @@ impl From<tokio::task::JoinError> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::NoGoodCrf { .. } => "Failed to find a suitable crf".fmt(f),
+            Self::NoGoodCrf {
+                last,
+                min_score,
+                max_encoded_percent,
+                score_kind,
+            } => {
+                let score_too_low = last.enc.score < *min_score;
+                let encode_too_large = last.enc.encode_percent > *max_encoded_percent as f64;
+                let reason = match (score_too_low, encode_too_large) {
+                    (true, true) => "score too low and encode too large",
+                    (true, false) => "score too low",
+                    (false, true) => "encode too large",
+                    (false, false) => "unknown",
+                };
+                write!(
+                    f,
+                    "Failed to find a suitable crf: {} \
+                    (target: {} >= {}, size <= {}%, \
+                    best: crf {}, {} {:.2}, size {:.0}%)",
+                    reason,
+                    score_kind,
+                    min_score,
+                    max_encoded_percent,
+                    TerseF32(last.crf),
+                    last.enc.score_kind,
+                    last.enc.score,
+                    last.enc.encode_percent
+                )
+            }
             Self::Other(err) => err.fmt(f),
         }
     }


### PR DESCRIPTION
Add `--stdout-format` argument accepting `human` (default) or `json`.

When using JSON format, outputs NDJSON with:
* Intermediate attempts: `{"type":"attempt","crf":...,"vmaf":...}`
* Final result: `{"type":"result","crf":...,"predicted_encode_size":...}`

NDJSON is used since crf-search is a long running command and it allows output to be streamed to show progress and also allows partial output in case the program exits or fails.

Fixes https://github.com/alexheretic/ab-av1/issues/313