### PR TITLE
svt-av1: Widen default crf search range to [5, 70]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased (0.11)
-* libsvtav1: Support crf quarter steps. Default `--crf-increment` to 0.25 for this encoder.
+* svt-av1: Support crf quarter steps. Default `--crf-increment` to 0.25 for this encoder.
   This requires svt-av1 >= v4.0.0, if using an older version you may want to use crf-search with `--crf-increment 1`.
+* svt-av1: Widen default crf search range [10, 55] -> [5, 70].
 
 # v0.10.4
 * Use ffmpeg `-fps_mode passthrough` for all sample encodes. This improves VMAF scores in some cases.

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -392,6 +392,7 @@ impl Encoder {
     pub fn default_min_crf(&self) -> f32 {
         match self.as_str() {
             "mpeg2video" => 2.0,
+            "libsvtav1" => 5.0,
             _ => 10.0,
         }
     }
@@ -402,7 +403,7 @@ impl Encoder {
             "libx264" | "libx265" => 46.0,
             "mpeg2video" => 30.0,
             "hevc_videotoolbox" => 100.0,
-            // Works well for svt-av1
+            "libsvtav1" => 70.0,
             _ => 55.0,
         }
     }


### PR DESCRIPTION
svt-av1: Widen default crf search range [10, 55] -> [5, 70]

### Tests
```
$ ab-av1 crf-search -i 4kmedia-spacex-launch-demo.mp4 --preset 11 --min-xpsnr 41
   Compiling ab-av1 v0.10.4 (/home/alex/project/ab-av1)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.47s
     Running `/home/alex/.cache/cargo/target/debug/ab-av1 crf-search -i 4kmedia-spacex-launch-demo.mp4 --preset 11 --min-xpsnr 41`
- crf 37.5 XPSNR 42.73 (6%)
- crf 57 XPSNR 39.07 (2%)
- crf 46.75 XPSNR 41.30 (3%)
  00:02:08 crf 48.25 1/1 ######################################################################################################################################## (eta 0s)
Encode with: ab-av1 encode -i 4kmedia-spacex-launch-demo.mp4 --crf 48.25 --preset 11

crf 48.25 XPSNR 41.07 predicted video stream size 4.65 MiB (3%) taking 84 seconds

$ ab-av1 crf-search -i 4kmedia-spacex-launch-demo.mp4 --preset 11 --min-xpsnr 46
- crf 37.5 XPSNR 42.73 (6%) (cache)
- crf 18 XPSNR 45.04 (31%) (cache)
- crf 5 XPSNR 48.12 (232%)
- crf 14 XPSNR 45.72 (49%)
- crf 13 XPSNR 45.93 (56%)
- crf 12.75 XPSNR 45.96 (57%)
  00:02:52 crf 12.5 1/1 ######################################################################################################################################### (eta 0s)
Encode with: ab-av1 encode -i 4kmedia-spacex-launch-demo.mp4 --crf 12.5 --preset 11

crf 12.5 XPSNR 46.00 predicted video stream size 103.79 MiB (59%) taking 2 minutes
```