### PR TITLE
Fix svt-av1 crf > 63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased (0.11)
 * svt-av1: Support crf quarter steps. Default `--crf-increment` to 0.25 for this encoder.
-  This requires svt-av1 >= v4.0.0, if using an older version you may want to use crf-search with `--crf-increment 1`.
+  This requires svt-av1 >= [v4.0.0](https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/CHANGELOG.md#400---2026-01-13), 
+  if using an older version you may want to use crf-search with `--crf-increment 1`.
 * svt-av1: Widen default crf search range [10, 55] -> [5, 70].
 
 # v0.10.4

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -331,7 +331,8 @@ impl Encode {
             vcodec: Arc::clone(vcodec),
             pix_fmt,
             vfilter: self.vfilter.as_deref(),
-            crf,
+            // ffmpeg svt-av1 crf above 63 don't work, but up to 70 does work in -svtav1-params
+            crf: if svtav1 { crf.min(63.0) } else { crf },
             preset,
             output_args: args,
             input_args,


### PR DESCRIPTION
ffmpeg fails using svt-av1 crf higher than 63, though the encoder will work up to 70. Fix by capping the _ffmpeg_ crf value to 63, but passing the correct crf in -svtav1-params.

### Tests
```
$ for crf in 60 62 63 64 65 69.75 70 70.25
    echo "==> --crf $crf"
    ab-av1 sample-encode -i 4kmedia-spacex-launch-demo.mp4 --preset 12 --crf $crf --xpsnr 2>/dev/null
  end
==> --crf 60
XPSNR 37.71 predicted video stream size 2.03 MiB (1%) taking 79 seconds
==> --crf 62
XPSNR 35.37 predicted video stream size 1.40 MiB (1%) taking 77 seconds
==> --crf 63
XPSNR 33.73 predicted video stream size 1.13 MiB (1%) taking 77 seconds
==> --crf 64
XPSNR 33.07 predicted video stream size 1.06 MiB (1%) taking 77 seconds
==> --crf 65
XPSNR 32.67 predicted video stream size 1018.93 KiB (1%) taking 79 seconds
==> --crf 69.75
XPSNR 31.34 predicted video stream size 884.54 KiB (0%) taking 77 seconds
==> --crf 70
XPSNR 30.94 predicted video stream size 868.41 KiB (0%) taking 77 seconds
==> --crf 70.25
# fails
```