### PR TITLE
Add sample-encode `--xpsnr --and-vmaf` compute both XPSNR and VMAF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (v0.11.3)
+* Add sample-encode support for computing both XPSNR **and** VMAF using `--xpsnr --do-vmaf`.
+
 # v0.11.2
 * Add arg `--xpsnr-pix-format` for setting an explicit pixel format to use in XPSNR analysis.
   This can be used to workaround some issues with 10-bit video, by setting `--xpsnr-pix-format yuv420p`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased (v0.11.3)
-* Add sample-encode support for computing both XPSNR **and** VMAF using `--xpsnr --do-vmaf`.
+* Add sample-encode support for computing both XPSNR **and** VMAF using `--xpsnr --and-vmaf`.
 
 # v0.11.2
 * Add arg `--xpsnr-pix-format` for setting an explicit pixel format to use in XPSNR analysis.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -170,9 +170,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -563,9 +563,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -576,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -605,9 +605,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -629,21 +629,21 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "once_cell"
@@ -830,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -849,9 +849,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1063,9 +1063,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1076,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "blake3"
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
@@ -770,7 +770,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/src/command/args/vmaf.rs
+++ b/src/command/args/vmaf.rs
@@ -12,7 +12,7 @@ pub struct Vmaf {
     /// So using this allows both vmaf & xpsnr to be calculated at the same time.
     // TODO: nicer if named "--vmaf"
     #[arg(long, num_args=0..=1, default_missing_value = "true")]
-    pub do_vmaf: Option<bool>,
+    pub and_vmaf: Option<bool>,
 
     /// Additional vmaf arg(s). E.g. --vmaf n_threads=8 --vmaf n_subsample=4
     ///
@@ -51,7 +51,7 @@ pub struct Vmaf {
 impl Default for Vmaf {
     fn default() -> Self {
         Self {
-            do_vmaf: None,
+            and_vmaf: None,
             vmaf_args: <_>::default(),
             vmaf_scale: <_>::default(),
             vmaf_fps: DEFAULT_VMAF_FPS,
@@ -61,7 +61,7 @@ impl Default for Vmaf {
 
 impl std::hash::Hash for Vmaf {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.do_vmaf.hash(state);
+        self.and_vmaf.hash(state);
         self.vmaf_args.hash(state);
         self.vmaf_scale.hash(state);
         self.vmaf_fps.to_ne_bytes().hash(state);

--- a/src/command/args/vmaf.rs
+++ b/src/command/args/vmaf.rs
@@ -8,6 +8,12 @@ const DEFAULT_VMAF_FPS: f32 = 25.0;
 /// Common vmaf options.
 #[derive(Debug, Parser, Clone)]
 pub struct Vmaf {
+    /// Set to calculate vmaf when it would otherwise not be, e.g. when calculating xpsnr.
+    /// So using this allows both vmaf & xpsnr to be calculated at the same time.
+    // TODO: nicer if named "--vmaf"
+    #[arg(long, num_args=0..=1, default_missing_value = "true")]
+    pub do_vmaf: Option<bool>,
+
     /// Additional vmaf arg(s). E.g. --vmaf n_threads=8 --vmaf n_subsample=4
     ///
     /// By default `n_threads` is set to available system threads.
@@ -45,6 +51,7 @@ pub struct Vmaf {
 impl Default for Vmaf {
     fn default() -> Self {
         Self {
+            do_vmaf: None,
             vmaf_args: <_>::default(),
             vmaf_scale: <_>::default(),
             vmaf_fps: DEFAULT_VMAF_FPS,
@@ -54,6 +61,7 @@ impl Default for Vmaf {
 
 impl std::hash::Hash for Vmaf {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.do_vmaf.hash(state);
         self.vmaf_args.hash(state);
         self.vmaf_scale.hash(state);
         self.vmaf_fps.to_ne_bytes().hash(state);

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -92,15 +92,15 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
                             .template(SPINNER_FINISHED)?
                             .progress_chars(PROGRESS_CHARS),
                     );
-                    let mut vmaf = style(last.enc.score);
-                    if last.enc.score < min_score {
+                    let mut vmaf = style(last.enc.single_score());
+                    if last.enc.single_score() < min_score {
                         vmaf = vmaf.red();
                     }
                     let mut percent = style!("{:.0}%", last.enc.encode_percent);
                     if last.enc.encode_percent > max_encoded_percent as _ {
                         percent = percent.red();
                     }
-                    let score_kind = last.enc.score_kind;
+                    let score_kind = last.enc.single_score_kind();
                     bar.finish_with_message(format!("{score_kind} {vmaf:.2}, size {percent}"));
                 }
                 bar.finish();
@@ -164,8 +164,8 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
     );
     bar.finish_with_message(format!(
         "{} {:.2}, size {}",
-        best.enc.score_kind,
-        style(best.enc.score).green(),
+        best.enc.single_score_kind(),
+        style(best.enc.single_score()).green(),
         style(format!("{:.0}%", best.enc.encode_percent)).green(),
     ));
     temporary::clean_all().await;

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -297,13 +297,13 @@ pub fn run(
                 q,
                 enc: sample_enc_output.context("no sample output?")?,
             };
-
+            let score = sample.enc.single_score();
             crf_attempts.push(sample.clone());
             let sample_small_enough = sample.enc.encode_percent <= max_encoded_percent as _;
 
-            if sample.enc.score > min_score {
+            if score > min_score {
                 // good
-                if sample_small_enough && sample.enc.score < min_score + higher_tolerance {
+                if sample_small_enough && score < min_score + higher_tolerance {
                     yield Update::Done(sample);
                     return;
                 }
@@ -377,8 +377,8 @@ impl Sample {
             info!(
                 "crf {} {} {:.2} ({:.0}%){}",
                 TerseF32(self.crf),
-                self.enc.score_kind,
-                self.enc.score,
+                self.enc.single_score_kind(),
+                self.enc.single_score(),
                 self.enc.encode_percent,
                 if self.enc.from_cache { " (cache)" } else { "" }
             );
@@ -387,8 +387,10 @@ impl Sample {
 
         let crf_label = style("- crf").dim();
         let mut crf = style(TerseF32(self.crf));
-        let vmaf_label = style(self.enc.score_kind).dim();
-        let mut vmaf = style(self.enc.score);
+
+        let score_v = self.enc.single_score();
+        let mut score = style(score_v);
+        let score_label = style(self.enc.single_score_kind()).dim();
         let mut percent = style!("{:.0}%", self.enc.encode_percent);
         let open = style("(").dim();
         let close = style(")").dim();
@@ -397,9 +399,9 @@ impl Sample {
             false => style(""),
         };
 
-        if self.enc.score < min_score {
+        if score_v < min_score {
             crf = crf.red().bright();
-            vmaf = vmaf.red().bright();
+            score = score.red().bright();
         }
         if self.enc.encode_percent > max_encoded_percent as _ {
             crf = crf.red().bright();
@@ -407,7 +409,7 @@ impl Sample {
         }
 
         bar.println(format!(
-            "{crf_label} {crf} {vmaf_label} {vmaf:.2} {open}{percent}{close}{cache_msg}"
+            "{crf_label} {crf} {score_label} {score:.2} {open}{percent}{close}{cache_msg}"
         ));
     }
 }
@@ -423,8 +425,8 @@ impl StdoutFormat {
             Self::Human => {
                 let crf = style(TerseF32(sample.crf)).bold().green();
                 let enc = &sample.enc;
-                let score = style(enc.score).bold().green();
-                let score_kind = enc.score_kind;
+                let score = style(enc.single_score()).bold().green();
+                let score_kind = enc.single_score_kind();
                 let size = style(HumanBytes(enc.predicted_encode_size)).bold().green();
                 let percent = style!("{}%", enc.encode_percent.round()).bold().green();
                 let time = style(HumanDuration(enc.predicted_encode_time)).bold();
@@ -453,14 +455,14 @@ impl StdoutFormat {
 /// This would be helpful particularly for small crf-increments.
 fn vmaf_lerp_q(min_vmaf: f32, worse_q: &Sample, better_q: &Sample) -> i64 {
     assert!(
-        worse_q.enc.score <= min_vmaf
-            && worse_q.enc.score < better_q.enc.score
+        worse_q.enc.single_score() <= min_vmaf
+            && worse_q.enc.single_score() < better_q.enc.single_score()
             && worse_q.q > better_q.q,
         "invalid vmaf_lerp_crf usage: ({min_vmaf}, {worse_q:?}, {better_q:?})"
     );
 
-    let vmaf_diff = better_q.enc.score - worse_q.enc.score;
-    let vmaf_factor = (min_vmaf - worse_q.enc.score) / vmaf_diff;
+    let vmaf_diff = better_q.enc.single_score() - worse_q.enc.single_score();
+    let vmaf_factor = (min_vmaf - worse_q.enc.single_score()) / vmaf_diff;
 
     let q_diff = worse_q.q - better_q.q;
     let lerp = (worse_q.q as f32 - q_diff as f32 * vmaf_factor).round() as i64;

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -4,7 +4,6 @@ use crate::{
     command::{
         PROGRESS_CHARS, SmallDuration,
         args::{self, PixelFormat},
-        sample_encode::cache::ScoringInfo,
     },
     console_ext::style,
     ffmpeg::{self, FfmpegEncodeArgs, remove_arg},
@@ -15,7 +14,7 @@ use crate::{
     vmaf::{self, VmafOut},
     xpsnr::{self, XpsnrOut},
 };
-use anyhow::{Context, ensure};
+use anyhow::ensure;
 use clap::{ArgAction, Parser};
 use console::style;
 use futures_util::Stream;
@@ -169,10 +168,11 @@ pub fn run(
         let samples = sample_args.sample_count(duration).max(1);
         let keep = sample_args.keep;
         let temp_dir = sample_args.temp_dir;
-        let scoring = match xpsnr {
-            true => ScoringInfo::Xpsnr(&xpsnr_opts, &score),
-            _ => ScoringInfo::Vmaf(&vmaf, &score),
-        };
+        // let scoring = ScoringInfo {
+        //     args: &score,
+        //     vmaf: &vmaf,
+        //     xpsnr: &xpsnr,
+        // };
 
         let (samples, sample_duration, full_pass) = {
             if input_is_image {
@@ -250,7 +250,7 @@ pub fn run(
                 input_len,
                 full_pass,
                 &enc_args,
-                scoring,
+                (&score, &vmaf, &xpsnr),
             )
             .await
             {
@@ -291,125 +291,126 @@ pub fn run(
                     let encoded_size = fs::metadata(&encoded_sample).await?.len();
                     let encoded_probe = ffprobe::probe(&encoded_sample);
 
-                    let result = match scoring {
-                        ScoringInfo::Vmaf(..) => {
-                            yield Update::Status(Status {
-                                work: Work::Score(ScoreKind::Vmaf),
-                                fps: 0.0,
-                                progress: (sample_idx as f32 + 0.5) / samples as f32,
-                                full_pass,
-                                sample: sample_n,
-                                samples,
-                            });
-                            let vmaf = vmaf::run(
-                                &sample,
-                                &encoded_sample,
-                                &vmaf.ffmpeg_lavfi(
-                                    encoded_probe.resolution,
-                                    PixelFormat::opt_max(enc_args.pix_fmt, input_pix_fmt),
-                                    score.reference_vfilter.as_deref().or(args.vfilter.as_deref()),
-                                ),
-                                vmaf.fps(),
-                            )?;
-                            let mut vmaf = pin!(vmaf);
-                            let mut logger = ProgressLogger::new("ab_av1::vmaf", Instant::now());
-                            let mut vmaf_score = None;
-                            while let Some(vmaf) = vmaf.next().await {
-                                match vmaf {
-                                    VmafOut::Done(score) => {
-                                        vmaf_score = Some(score);
-                                    }
-                                    VmafOut::Progress(FfmpegOut::Progress { time, fps, .. }) => {
-                                        yield Update::Status(Status {
-                                            work: Work::Score(ScoreKind::Vmaf),
-                                            fps,
-                                            progress: (sample_duration_us +
-                                                time.as_micros_u64() +
-                                                sample_idx * sample_duration_us * 2) as f32
-                                                / (sample_duration_us * samples * 2) as f32,
-                                            full_pass,
-                                            sample: sample_n,
-                                            samples,
-                                        });
-                                        logger.update(sample_duration, time, fps);
-                                    }
-                                    VmafOut::Progress(_) => {}
-                                    VmafOut::Err(e) => Err(e)?,
-                                }
-                            }
-
-                            EncodeResult {
-                                score: vmaf_score.context("no vmaf score")?,
-                                score_kind: ScoreKind::Vmaf,
-                                sample_size,
-                                encoded_size,
-                                encode_time,
-                                sample_duration: encoded_probe
-                                    .duration
-                                    .ok()
-                                    .filter(|d| !d.is_zero())
-                                    .unwrap_or(sample_duration),
-                                from_cache: false,
-                            }
-                        }
-                        ScoringInfo::Xpsnr(..) => {
-                            yield Update::Status(Status {
-                                work: Work::Score(ScoreKind::Xpsnr),
-                                fps: 0.0,
-                                progress: (sample_idx as f32 + 0.5) / samples as f32,
-                                full_pass,
-                                sample: sample_n,
-                                samples,
-                            });
-
-                            let lavfi = super::xpsnr::lavfi(
-                                score.reference_vfilter.as_deref().or(args.vfilter.as_deref()),
-                                xpsnr_opts.xpsnr_pix_format
-                                    .or_else(|| PixelFormat::opt_max(enc_args.pix_fmt, input_pix_fmt)),
-                            );
-                            let xpsnr_out = xpsnr::run(&sample, &encoded_sample, &lavfi, xpsnr_opts.fps())?;
-                            let mut xpsnr_out = pin!(xpsnr_out);
-                            let mut logger = ProgressLogger::new("ab_av1::xpsnr", Instant::now());
-                            let mut score = None;
-                            while let Some(next) = xpsnr_out.next().await {
-                                match next {
-                                    XpsnrOut::Done(s) => {
-                                        score = Some(s);
-                                    }
-                                    XpsnrOut::Progress(FfmpegOut::Progress { time, fps, .. }) => {
-                                        yield Update::Status(Status {
-                                            work: Work::Score(ScoreKind::Xpsnr),
-                                            fps,
-                                            progress: (sample_duration_us +
-                                                time.as_micros_u64() +
-                                                sample_idx * sample_duration_us * 2) as f32
-                                                / (sample_duration_us * samples * 2) as f32,
-                                            full_pass,
-                                            sample: sample_n,
-                                            samples,
-                                        });
-                                        logger.update(sample_duration, time, fps);
-                                    }
-                                    XpsnrOut::Progress(_) => {}
-                                    XpsnrOut::Err(e) => Err(e)?,
-                                }
-                            }
-
-                            EncodeResult {
-                                score: score.context("no xpsnr score")?,
-                                score_kind: ScoreKind::Xpsnr,
-                                sample_size,
-                                encoded_size,
-                                encode_time,
-                                sample_duration: encoded_probe
-                                    .duration
-                                    .ok()
-                                    .filter(|d| !d.is_zero())
-                                    .unwrap_or(sample_duration),
-                                from_cache: false,
-                            }
-                        }
+                    let mut result = EncodeResult {
+                        vmaf_score: None,
+                        xpsnr_score: None,
+                        sample_size,
+                        encoded_size,
+                        encode_time,
+                        sample_duration: encoded_probe
+                            .duration
+                            .ok()
+                            .filter(|d| !d.is_zero())
+                            .unwrap_or(sample_duration),
+                        from_cache: false,
                     };
+
+                    let do_vmaf = vmaf.do_vmaf.unwrap_or(!xpsnr);
+                    if xpsnr {
+                        yield Update::Status(Status {
+                            work: Work::Score(ScoreKind::Xpsnr),
+                            fps: 0.0,
+                            progress: (sample_idx as f32 + 0.5) / samples as f32,
+                            full_pass,
+                            sample: sample_n,
+                            samples,
+                        });
+
+                        let lavfi = super::xpsnr::lavfi(
+                            score.reference_vfilter.as_deref().or(args.vfilter.as_deref()),
+                            xpsnr_opts.xpsnr_pix_format
+                                .or_else(|| PixelFormat::opt_max(enc_args.pix_fmt, input_pix_fmt)),
+                        );
+                        let xpsnr_out = xpsnr::run(&sample, &encoded_sample, &lavfi, xpsnr_opts.fps())?;
+                        let mut xpsnr_out = pin!(xpsnr_out);
+                        let mut logger = ProgressLogger::new("ab_av1::xpsnr", Instant::now());
+                        while let Some(next) = xpsnr_out.next().await {
+                            match next {
+                                XpsnrOut::Done(s) => {
+                                    result.xpsnr_score = Some(s);
+                                }
+                                XpsnrOut::Progress(FfmpegOut::Progress { time, fps, .. }) => {
+                                    let progress = match do_vmaf {
+                                        false => (sample_duration_us +
+                                            time.as_micros_u64() +
+                                            sample_idx * sample_duration_us * 2) as f32
+                                            / (sample_duration_us * samples * 2) as f32,
+                                        true => (sample_duration_us +
+                                            time.as_micros_u64() / 2 +
+                                            sample_idx * sample_duration_us * 2) as f32
+                                            / (sample_duration_us * samples * 2) as f32
+                                    };
+                                    yield Update::Status(Status {
+                                        work: Work::Score(ScoreKind::Xpsnr),
+                                        fps,
+                                        progress,
+                                        full_pass,
+                                        sample: sample_n,
+                                        samples,
+                                    });
+                                    logger.update(sample_duration, time, fps);
+                                }
+                                XpsnrOut::Progress(_) => {}
+                                XpsnrOut::Err(e) => Err(e)?,
+                            }
+                        }
+                    }
+                    if do_vmaf {
+                        let init_progress = match xpsnr {
+                            false => (sample_idx as f32 + 0.5) / samples as f32,
+                            true => (sample_idx as f32 + 0.75) / samples as f32,
+                        };
+                        yield Update::Status(Status {
+                            work: Work::Score(ScoreKind::Vmaf),
+                            fps: 0.0,
+                            progress: init_progress,
+                            full_pass,
+                            sample: sample_n,
+                            samples,
+                        });
+                        let vmaf = vmaf::run(
+                            &sample,
+                            &encoded_sample,
+                            &vmaf.ffmpeg_lavfi(
+                                encoded_probe.resolution,
+                                PixelFormat::opt_max(enc_args.pix_fmt, input_pix_fmt),
+                                score.reference_vfilter.as_deref().or(args.vfilter.as_deref()),
+                            ),
+                            vmaf.fps(),
+                        )?;
+                        let mut vmaf = pin!(vmaf);
+                        let mut logger = ProgressLogger::new("ab_av1::vmaf", Instant::now());
+                        while let Some(vmaf) = vmaf.next().await {
+                            match vmaf {
+                                VmafOut::Done(score) => {
+                                    result.vmaf_score = Some(score);
+                                }
+                                VmafOut::Progress(FfmpegOut::Progress { time, fps, .. }) => {
+                                    let progress = match xpsnr {
+                                        false => (sample_duration_us +
+                                            time.as_micros_u64() +
+                                            sample_idx * sample_duration_us * 2) as f32
+                                            / (sample_duration_us * samples * 2) as f32,
+                                        true => (sample_duration_us + sample_duration_us / 2 +
+                                            time.as_micros_u64() / 2 +
+                                            sample_idx * sample_duration_us * 2) as f32
+                                            / (sample_duration_us * samples * 2) as f32,
+                                    };
+                                    yield Update::Status(Status {
+                                        work: Work::Score(ScoreKind::Vmaf),
+                                        fps,
+                                        progress,
+                                        full_pass,
+                                        sample: sample_n,
+                                        samples,
+                                    });
+                                    logger.update(sample_duration, time, fps);
+                                }
+                                VmafOut::Progress(_) => {}
+                                VmafOut::Err(e) => Err(e)?,
+                            }
+                        }
+                    }
 
                     if samples > 1 {
                         result.log_attempt(sample_n, samples, crf);
@@ -433,10 +434,9 @@ pub fn run(
             yield Update::SampleResult { sample: sample_n, result };
         }
 
-        let score_kind = results.score_kind();
         let output = Output {
-            score: results.mean_score(),
-            score_kind,
+            vmaf_score: results.mean_vmaf_score(),
+            xpsnr_score: results.mean_xpsnr_score(),
             // Using file size * encode_percent can over-estimate. However, if it ends up less
             // than the duration estimation it may turn out to be more accurate.
             predicted_encode_size: results
@@ -447,8 +447,13 @@ pub fn run(
             from_cache: results.iter().all(|r| r.from_cache),
         };
         info!(
-            "crf {crf} {score_kind} {:.2} predicted video stream size {} ({:.0}%) taking {}{}",
-            output.score,
+            "crf {crf}{}{} predicted video stream size {} ({:.0}%) taking {}{}",
+            output.vmaf_score
+                .map(|s| format!(" VMAF {s:.2}"))
+                .unwrap_or_default(),
+            output.xpsnr_score
+                .map(|s| format!(" XPSNR {s:.2}"))
+                .unwrap_or_default(),
             HumanBytes(output.predicted_encode_size),
             output.encode_percent,
             HumanDuration(output.predicted_encode_time),
@@ -493,8 +498,8 @@ async fn sample(
 pub struct EncodeResult {
     pub sample_size: u64,
     pub encoded_size: u64,
-    pub score: f32,
-    pub score_kind: ScoreKind,
+    pub vmaf_score: Option<f32>,
+    pub xpsnr_score: Option<f32>,
     pub encode_time: Duration,
     /// Duration of the sample.
     ///
@@ -509,16 +514,22 @@ impl EncodeResult {
         let Self {
             sample_size,
             encoded_size,
-            score,
-            score_kind,
+            vmaf_score,
+            xpsnr_score,
             from_cache,
             ..
         } = self;
         bar.println(
             style!(
-                "- {}Sample {sample_n} ({:.0}%) {score_kind} {score:.2}{}",
+                "- {}Sample {sample_n} ({:.0}%){}{}{}",
                 crf.map(|crf| format!("crf {crf}: ")).unwrap_or_default(),
                 100.0 * *encoded_size as f32 / *sample_size as f32,
+                vmaf_score
+                    .map(|s| format!(" VMAF {s:.2}"))
+                    .unwrap_or_default(),
+                xpsnr_score
+                    .map(|s| format!(" XPSNR {s:.2}"))
+                    .unwrap_or_default(),
                 if *from_cache { " (cache)" } else { "" },
             )
             .dim()
@@ -530,14 +541,20 @@ impl EncodeResult {
         let Self {
             sample_size,
             encoded_size,
-            score,
-            score_kind,
+            vmaf_score,
+            xpsnr_score,
             from_cache,
             ..
         } = self;
         info!(
-            "sample {sample_n}/{samples} crf {crf} {score_kind} {score:.2} ({:.0}%){}",
+            "sample {sample_n}/{samples} crf {crf}{}{} ({:.0}%){}",
             100.0 * *encoded_size as f32 / *sample_size as f32,
+            vmaf_score
+                .map(|s| format!(" VMAF {s:.2}"))
+                .unwrap_or_default(),
+            xpsnr_score
+                .map(|s| format!(" XPSNR {s:.2}"))
+                .unwrap_or_default(),
             if *from_cache { " (cache)" } else { "" }
         );
     }
@@ -576,9 +593,9 @@ impl Display for ScoreKind {
 trait EncodeResults {
     fn encoded_percent_size(&self) -> f64;
 
-    fn score_kind(&self) -> ScoreKind;
+    fn mean_vmaf_score(&self) -> Option<f32>;
 
-    fn mean_score(&self) -> f32;
+    fn mean_xpsnr_score(&self) -> Option<f32>;
 
     /// Return estimated encoded **video stream** size by multiplying sample size by duration.
     fn estimate_encode_size_by_duration(
@@ -589,6 +606,7 @@ trait EncodeResults {
 
     fn estimate_encode_time(&self, input_duration: Duration, single_full_pass: bool) -> Duration;
 }
+
 impl EncodeResults for Vec<EncodeResult> {
     fn encoded_percent_size(&self) -> f64 {
         if self.is_empty() {
@@ -599,17 +617,16 @@ impl EncodeResults for Vec<EncodeResult> {
         encoded * 100.0 / sample
     }
 
-    fn score_kind(&self) -> ScoreKind {
-        self.first()
-            .map(|r| r.score_kind)
-            .unwrap_or(ScoreKind::Vmaf)
+    fn mean_vmaf_score(&self) -> Option<f32> {
+        let mut scores = self.iter().filter_map(|r| r.vmaf_score).peekable();
+        scores.peek()?;
+        Some(scores.sum::<f32>() / self.len() as f32)
     }
 
-    fn mean_score(&self) -> f32 {
-        if self.is_empty() {
-            return 0.0;
-        }
-        self.iter().map(|r| r.score).sum::<f32>() / self.len() as f32
+    fn mean_xpsnr_score(&self) -> Option<f32> {
+        let mut scores = self.iter().filter_map(|r| r.xpsnr_score).peekable();
+        scores.peek()?;
+        Some(scores.sum::<f32>() / self.len() as f32)
     }
 
     fn estimate_encode_size_by_duration(
@@ -682,8 +699,8 @@ impl StdoutFormat {
     fn print_result(
         self,
         Output {
-            score,
-            score_kind,
+            vmaf_score,
+            xpsnr_score,
             predicted_encode_size,
             encode_percent,
             predicted_encode_time,
@@ -693,10 +710,17 @@ impl StdoutFormat {
     ) {
         match self {
             Self::Human => {
-                let score = match (*score, score_kind) {
-                    (v, ScoreKind::Vmaf) if v >= 95.0 => style(v).bold().green(),
-                    (v, ScoreKind::Vmaf) if v < 80.0 => style(v).bold().red(),
-                    (v, _) => style(v).bold(),
+                let vmaf_fmt = match *vmaf_score {
+                    None => format_args!(""),
+                    Some(s) => match s {
+                        _ if s >= 95.0 => format_args!("VMAF {} ", style(s).bold().green()),
+                        _ if s < 80.0 => format_args!("VMAF {} ", style(s).bold().red()),
+                        _ => format_args!("VMAF {} ", style(s).bold()),
+                    },
+                };
+                let xpsnr_fmt = match *xpsnr_score {
+                    None => format_args!(""),
+                    Some(s) => format_args!("XPSNR {} ", style(s).bold()),
                 };
                 let percent = encode_percent.round();
                 let size = match *predicted_encode_size {
@@ -715,7 +739,7 @@ impl StdoutFormat {
                     false => "video stream",
                 };
                 println!(
-                    "{score_kind} {score:.2} predicted {enc_description} size {size} ({percent}) taking {time}"
+                    "{vmaf_fmt}{xpsnr_fmt}predicted {enc_description} size {size} ({percent}) taking {time}"
                 );
             }
             Self::Json => {
@@ -724,9 +748,11 @@ impl StdoutFormat {
                     "predicted_encode_percent": encode_percent,
                     "predicted_encode_seconds": predicted_encode_time.as_secs_f64(),
                 });
-                match score_kind {
-                    ScoreKind::Vmaf => json["vmaf"] = (*score).into(),
-                    ScoreKind::Xpsnr => json["xpsnr"] = (*score).into(),
+                if let Some(score) = *vmaf_score {
+                    json["vmaf"] = score.into();
+                }
+                if let Some(score) = *xpsnr_score {
+                    json["xpsnr"] = score.into();
                 }
                 println!("{json}");
             }
@@ -737,9 +763,10 @@ impl StdoutFormat {
 /// Sample encode result.
 #[derive(Debug, Clone)]
 pub struct Output {
-    /// Sample mean score.
-    pub score: f32,
-    pub score_kind: ScoreKind,
+    /// Sample mean VMAF score.
+    pub vmaf_score: Option<f32>,
+    /// Sample mean XPSNR score.
+    pub xpsnr_score: Option<f32>,
     /// Estimated full encoded **video stream** size.
     ///
     /// Encoded sample size multiplied by duration.
@@ -752,6 +779,21 @@ pub struct Output {
     pub predicted_encode_time: Duration,
     /// All sample results were read from the cache.
     pub from_cache: bool,
+}
+
+impl Output {
+    /// Extract vmaf or xpsnr score. Use when it is expected to have only 1 of these.
+    pub fn single_score(&self) -> f32 {
+        self.vmaf_score.or(self.xpsnr_score).unwrap_or_default()
+    }
+
+    /// Extract vmaf or xpsnr kind. Use when it is expected to have only 1 of these.
+    pub fn single_score_kind(&self) -> ScoreKind {
+        match self.vmaf_score {
+            Some(_) => ScoreKind::Vmaf,
+            _ => ScoreKind::Xpsnr,
+        }
+    }
 }
 
 /// Kinds of sample-encode work.

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -305,7 +305,7 @@ pub fn run(
                         from_cache: false,
                     };
 
-                    let do_vmaf = vmaf.do_vmaf.unwrap_or(!xpsnr);
+                    let do_vmaf = vmaf.and_vmaf.unwrap_or(!xpsnr);
                     if xpsnr {
                         yield Update::Status(Status {
                             work: Work::Score(ScoreKind::Xpsnr),

--- a/src/command/sample_encode/cache.rs
+++ b/src/command/sample_encode/cache.rs
@@ -1,8 +1,5 @@
 //! _sample-encode_ file system caching logic.
-use crate::{
-    command::args::{ScoreArgs, Vmaf, Xpsnr},
-    ffmpeg::FfmpegEncodeArgs,
-};
+use crate::ffmpeg::FfmpegEncodeArgs;
 use anyhow::Context;
 use std::{
     ffi::OsStr,
@@ -21,7 +18,7 @@ pub async fn cached_encode(
     input_size: u64,
     full_pass: bool,
     enc_args: &FfmpegEncodeArgs<'_>,
-    scoring: ScoringInfo<'_>,
+    scoring: impl Hash,
 ) -> (Option<super::EncodeResult>, Option<Key>) {
     if !cache {
         return (None, None);
@@ -66,12 +63,6 @@ pub async fn cached_encode(
             (None, None)
         }
     }
-}
-
-#[derive(Debug, Hash, Clone, Copy)]
-pub enum ScoringInfo<'a> {
-    Vmaf(&'a Vmaf, &'a ScoreArgs),
-    Xpsnr(&'a Xpsnr, &'a ScoreArgs),
 }
 
 pub async fn cache_result(key: Key, result: &super::EncodeResult) -> anyhow::Result<()> {

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -54,7 +54,6 @@ impl FfmpegEncodeArgs<'_> {
         self.preset.hash(state);
         self.output_args.hash(state);
         self.input_args.hash(state);
-        20250103.hash(state); // introduced -fps_mode passthrough
     }
 }
 

--- a/src/xpsnr.rs
+++ b/src/xpsnr.rs
@@ -8,6 +8,7 @@ use tokio_process_stream::{Item, ProcessChunkStream};
 use tokio_stream::{Stream, StreamExt};
 
 /// Calculate XPSNR score using ffmpeg.
+// TODO: fix progress update to account for fps
 pub fn run(
     reference: &Path,
     distorted: &Path,

--- a/stdout-format-json.md
+++ b/stdout-format-json.md
@@ -8,8 +8,8 @@ Field | Description | Type/Units
 `predicted_encode_percent` | Predicted output encode size percentage vs input | float
 `predicted_encode_seconds` | Predicted output encode time in seconds | float
 `predicted_encode_size` | Predicted output encode size in bytes | uint
-`vmaf` | VMAF score (absent when using --xpsnr without --do-vmaf) | float
-`xpsnr` | XPSNR score (present only when using --xpsnr) | float
+`vmaf` | VMAF score (present when requested (default)) | float
+`xpsnr` | XPSNR score (present when requested) | float
 
 ### Example
 ```json

--- a/stdout-format-json.md
+++ b/stdout-format-json.md
@@ -8,7 +8,7 @@ Field | Description | Type/Units
 `predicted_encode_percent` | Predicted output encode size percentage vs input | float
 `predicted_encode_seconds` | Predicted output encode time in seconds | float
 `predicted_encode_size` | Predicted output encode size in bytes | uint
-`vmaf` | VMAF score (absent when using --xpsnr) | float
+`vmaf` | VMAF score (absent when using --xpsnr without --do-vmaf) | float
 `xpsnr` | XPSNR score (present only when using --xpsnr) | float
 
 ### Example


### PR DESCRIPTION
Add sample-encode `--and-vmaf` arg that allows running xpsnr **and** vmaf analysis on a sample.

* `ab-av1 sample-encode ...` calculate vmaf only, as before.
* `ab-av1 sample-encode --xpsnr ...` calculate xpsnr only, as before.
* `ab-av1 sample-encode --xpsnr --and-vmaf ...` calculate both.

# Examples

```
$ ab-av1 sample-encode -i pixabay-lemon-82602.mp4 --crf 25 --xpsnr --and-vmaf
- Sample 1 (38%) VMAF 95.99 XPSNR 40.84
  00:01:01 Sample 1/1 ################################# (vmaf 18 fps, eta 0s)
Encode with: ab-av1 encode -i pixabay-lemon-82602.mp4 --crf 25

VMAF 95.98887 XPSNR 40.8396 predicted video stream size 34.04 MiB (38%) taking 50 seconds


$ ab-av1 sample-encode -i pixabay-lemon-82602.mp4 --crf 25 --xpsnr --and-vmaf --stdout-format json
- Sample 1 (38%) VMAF 95.99 XPSNR 40.84 (cache)
  00:00:00 Sample 1/1 ################################# (encoding,  eta 0s)
Encode with: ab-av1 encode -i pixabay-lemon-82602.mp4 --crf 25

{"predicted_encode_percent":37.64505024257469,"predicted_encode_seconds":50.0,"predicted_encode_size":35693834,"vmaf":95.9888687133789,"xpsnr":40.839599609375}
```

## Impl issues
* Couldn't use `--vmaf` without breaking the cli as this is already used for vmaf args.
* xpsnr & vmaf are run sequentially, but we could run them concurrently.
* caching logic is crude, if both are calculated but later only one is requested the cache won't work.

Resolves #355