### PR TITLE
Fix score subprocess shutdown tracking

### DIFF
--- a/src/process/child.rs
+++ b/src/process/child.rs
@@ -15,6 +15,41 @@ use tokio_process_stream::ProcessChunkStream;
 
 static RUNNING: LazyLock<Mutex<Vec<ProcessChunkStream>>> = LazyLock::new(<_>::default);
 
+struct RegisteredChildren(Vec<ProcessChunkStream>);
+
+impl RegisteredChildren {
+    fn take() -> Self {
+        Self(mem::take(&mut *RUNNING.lock().unwrap()))
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [ProcessChunkStream] {
+        &mut self.0
+    }
+}
+
+impl Drop for RegisteredChildren {
+    fn drop(&mut self) {
+        if self.0.is_empty() {
+            return;
+        }
+
+        let mut running = RUNNING.lock().unwrap();
+        running.retain_mut(|child| {
+            child
+                .child_mut()
+                .is_some_and(|child| matches!(child.try_wait(), Ok(None)))
+        });
+        for mut child in self.0.drain(..) {
+            if child
+                .child_mut()
+                .is_some_and(|child| matches!(child.try_wait(), Ok(None)))
+            {
+                running.push(child);
+            }
+        }
+    }
+}
+
 /// Add a child process so it may be waited on before exiting.
 pub fn add(mut child: ProcessChunkStream) {
     let mut running = RUNNING.lock().unwrap();
@@ -37,10 +72,10 @@ pub fn add(mut child: ProcessChunkStream) {
 pub async fn wait() {
     // if waiting takes >500ms log what's happening
     let mut log_deadline = Some(Instant::now() + Duration::from_millis(500));
-    let procs = mem::take(&mut *RUNNING.lock().unwrap());
+    let mut procs = RegisteredChildren::take();
     let mut ctrl_c = pin!(signal::ctrl_c());
 
-    for mut proc in procs {
+    for proc in procs.as_mut_slice() {
         if let Some(child) = proc.child_mut() {
             if let Some(deadline) = log_deadline
                 && timeout_at(deadline, child.wait()).await.is_err()
@@ -194,5 +229,40 @@ mod tests {
 
         wait().await;
         clear_running();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelled_wait_keeps_unfinished_children_registered() {
+        let _guard = test_guard();
+        clear_running();
+
+        let mut child = Command::new("sh");
+        child
+            .arg("-c")
+            .arg("sleep 0.2")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = child.spawn().expect("spawn running child");
+
+        add(ProcessChunkStream::from(child));
+
+        let timed_out = tokio::time::timeout(Duration::from_millis(10), wait())
+            .await
+            .is_err();
+        let registered_after_cancel = running_len();
+
+        if registered_after_cancel > 0 {
+            wait().await;
+        } else {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        clear_running();
+
+        assert!(timed_out, "wait should still be pending for a live child");
+        assert_eq!(
+            registered_after_cancel, 1,
+            "cancelling wait should not drop unfinished children from the shutdown registry"
+        );
     }
 }

--- a/src/process/child.rs
+++ b/src/process/child.rs
@@ -47,6 +47,20 @@ impl RegisteredChildren {
     fn as_mut_slice(&mut self) -> &mut [ProcessChunkStream] {
         &mut self.0
     }
+
+    async fn kill_and_reap_all(&mut self) {
+        for proc in &mut self.0 {
+            if let Some(child) = proc.child_mut()
+                && child.try_wait().is_ok_and(|status| status.is_none())
+            {
+                _ = child.kill().await;
+            }
+        }
+    }
+
+    fn discard(mut self) {
+        self.0.clear();
+    }
 }
 
 impl Drop for RegisteredChildren {
@@ -74,26 +88,39 @@ pub fn add(child: ProcessChunkStream) {
 
 /// Wait for all child processes, that were added with [`add`], to exit.
 pub async fn wait() {
-    // if waiting takes >500ms log what's happening
-    let mut log_deadline = Some(Instant::now() + Duration::from_millis(500));
     let mut procs = RegisteredChildren::take();
     let mut ctrl_c = pin!(signal::ctrl_c());
 
-    for proc in procs.as_mut_slice() {
+    tokio::select! {
+        _ = &mut ctrl_c => {
+            log_abort_wait();
+            procs.kill_and_reap_all().await;
+            procs.discard();
+        }
+        _ = wait_for_children(
+            procs.as_mut_slice(),
+            Duration::from_millis(500),
+            log_waiting,
+        ) => {}
+    }
+}
+
+async fn wait_for_children(
+    procs: &mut [ProcessChunkStream],
+    slow_wait_after: Duration,
+    mut on_slow_wait: impl FnMut(),
+) {
+    let mut log_deadline = Some(Instant::now() + slow_wait_after);
+
+    for proc in procs {
         if let Some(child) = proc.child_mut() {
             if let Some(deadline) = log_deadline
                 && timeout_at(deadline, child.wait()).await.is_err()
             {
-                log_waiting();
+                on_slow_wait();
                 log_deadline = None;
             }
-            tokio::select! {
-                _ = &mut ctrl_c => {
-                    log_abort_wait();
-                    return;
-                }
-                _ = child.wait() => {}
-            }
+            let _ = child.wait().await;
         }
     }
 }
@@ -165,6 +192,13 @@ mod tests {
         running_registry().len()
     }
 
+    fn all_children_reaped(registered: &mut RegisteredChildren) -> bool {
+        registered
+            .as_mut_slice()
+            .iter_mut()
+            .all(|proc| !is_running(proc))
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn add_tracks_running_child() {
         let _guard = test_guard();
@@ -172,8 +206,9 @@ mod tests {
 
         let mut child = Command::new("sh");
         child
+            .kill_on_drop(true)
             .arg("-c")
-            .arg("sleep 5")
+            .arg("sleep 1")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
@@ -215,7 +250,7 @@ mod tests {
         let mut child = Command::new("sh");
         child
             .arg("-c")
-            .arg("sleep 5")
+            .arg("sleep 1")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
@@ -308,6 +343,71 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn aborting_shutdown_wait_kills_reaps_and_discards_unfinished_children() {
+        let _guard = test_guard();
+        clear_running();
+
+        let mut child = Command::new("sh");
+        child
+            .kill_on_drop(true)
+            .arg("-c")
+            .arg("sleep 1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = child.spawn().expect("spawn running child");
+
+        add(ProcessChunkStream::from(child));
+        let mut registered = RegisteredChildren::take();
+        registered.kill_and_reap_all().await;
+        let killed_and_reaped = all_children_reaped(&mut registered);
+        registered.discard();
+
+        assert_eq!(
+            running_len(),
+            0,
+            "aborted shutdown children should not be re-registered"
+        );
+        assert!(
+            killed_and_reaped,
+            "aborted shutdown children should be killed and reaped before discard"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn aborting_shutdown_wait_reaps_children_that_exit_before_cleanup() {
+        let _guard = test_guard();
+        clear_running();
+
+        let mut child = Command::new("sh");
+        child
+            .arg("-c")
+            .arg("sleep 0.05")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = child.spawn().expect("spawn short-lived child");
+
+        add(ProcessChunkStream::from(child));
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let mut registered = RegisteredChildren::take();
+        registered.kill_and_reap_all().await;
+        let reaped = all_children_reaped(&mut registered);
+        registered.discard();
+
+        assert_eq!(
+            running_len(),
+            0,
+            "aborted shutdown children should not be re-registered after exit races"
+        );
+        assert!(
+            reaped,
+            "children that exit before abort cleanup should still be reaped before discard"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn add_prunes_children_that_already_exited() {
         let _guard = test_guard();
         clear_running();
@@ -343,5 +443,57 @@ mod tests {
 
         wait().await;
         clear_running();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn wait_for_children_waits_for_supplied_children() {
+        let _guard = test_guard();
+        clear_running();
+
+        let mut child = Command::new("sh");
+        child
+            .arg("-c")
+            .arg("sleep 0.1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = child.spawn().expect("spawn short-lived child");
+        let mut children = vec![ProcessChunkStream::from(child)];
+        let mut slow_wait_logged = false;
+
+        wait_for_children(&mut children, Duration::from_secs(60), || {
+            slow_wait_logged = true
+        })
+        .await;
+
+        assert!(!slow_wait_logged, "short waits should not log");
+        assert!(
+            children.iter_mut().all(|child| !is_running(child)),
+            "wait_for_children should leave supplied children exited"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn wait_for_children_logs_once_after_slow_wait_threshold() {
+        let _guard = test_guard();
+        clear_running();
+
+        let mut child = Command::new("sh");
+        child
+            .arg("-c")
+            .arg("sleep 0.1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = child.spawn().expect("spawn slow child");
+        let mut children = vec![ProcessChunkStream::from(child)];
+        let mut slow_wait_logs = 0;
+
+        wait_for_children(&mut children, Duration::from_millis(10), || {
+            slow_wait_logs += 1
+        })
+        .await;
+
+        assert_eq!(slow_wait_logs, 1, "slow wait should log once");
     }
 }

--- a/src/process/child.rs
+++ b/src/process/child.rs
@@ -2,9 +2,9 @@ use log::info;
 use std::{
     io::IsTerminal,
     mem,
-    ops::{Deref, DerefMut},
-    pin::pin,
-    sync::{LazyLock, Mutex},
+    pin::{Pin, pin},
+    sync::{LazyLock, Mutex, MutexGuard},
+    task::{Context, Poll},
     time::Duration,
 };
 use tokio::{
@@ -12,14 +12,36 @@ use tokio::{
     time::{Instant, timeout_at},
 };
 use tokio_process_stream::ProcessChunkStream;
+use tokio_stream::Stream;
 
 static RUNNING: LazyLock<Mutex<Vec<ProcessChunkStream>>> = LazyLock::new(<_>::default);
+
+fn running_registry() -> MutexGuard<'static, Vec<ProcessChunkStream>> {
+    RUNNING
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn is_running(proc: &mut ProcessChunkStream) -> bool {
+    proc.child_mut()
+        .is_some_and(|child| matches!(child.try_wait(), Ok(None)))
+}
+
+fn prune_exited(running: &mut Vec<ProcessChunkStream>) {
+    running.retain_mut(is_running);
+}
+
+fn register_if_running(running: &mut Vec<ProcessChunkStream>, mut child: ProcessChunkStream) {
+    if is_running(&mut child) {
+        running.push(child);
+    }
+}
 
 struct RegisteredChildren(Vec<ProcessChunkStream>);
 
 impl RegisteredChildren {
     fn take() -> Self {
-        Self(mem::take(&mut *RUNNING.lock().unwrap()))
+        Self(mem::take(&mut *running_registry()))
     }
 
     fn as_mut_slice(&mut self) -> &mut [ProcessChunkStream] {
@@ -33,39 +55,21 @@ impl Drop for RegisteredChildren {
             return;
         }
 
-        let mut running = RUNNING.lock().unwrap();
-        running.retain_mut(|child| {
-            child
-                .child_mut()
-                .is_some_and(|child| matches!(child.try_wait(), Ok(None)))
-        });
-        for mut child in self.0.drain(..) {
-            if child
-                .child_mut()
-                .is_some_and(|child| matches!(child.try_wait(), Ok(None)))
-            {
-                running.push(child);
-            }
+        let mut running = running_registry();
+        prune_exited(&mut running);
+        for child in self.0.drain(..) {
+            register_if_running(&mut running, child);
         }
     }
 }
 
 /// Add a child process so it may be waited on before exiting.
-pub fn add(mut child: ProcessChunkStream) {
-    let mut running = RUNNING.lock().unwrap();
+pub fn add(child: ProcessChunkStream) {
+    let mut running = running_registry();
 
     // remove any that have exited already
-    running.retain_mut(|c| {
-        c.child_mut()
-            .is_some_and(|c| matches!(c.try_wait(), Ok(None)))
-    });
-
-    if child
-        .child_mut()
-        .is_some_and(|c| matches!(c.try_wait(), Ok(None)))
-    {
-        running.push(child);
-    }
+    prune_exited(&mut running);
+    register_if_running(&mut running, child);
 }
 
 /// Wait for all child processes, that were added with [`add`], to exit.
@@ -108,17 +112,17 @@ fn log_abort_wait() {
     }
 }
 
-/// Wrapper that [`add`]s the inner on drop.
+/// Stream wrapper that [`add`]s the inner child process on drop.
 #[derive(Debug)]
-pub struct AddOnDropChunkStream(Option<ProcessChunkStream>);
+pub struct TrackedChildStream(Option<ProcessChunkStream>);
 
-impl From<ProcessChunkStream> for AddOnDropChunkStream {
+impl From<ProcessChunkStream> for TrackedChildStream {
     fn from(v: ProcessChunkStream) -> Self {
         Self(Some(v))
     }
 }
 
-impl Drop for AddOnDropChunkStream {
+impl Drop for TrackedChildStream {
     fn drop(&mut self) {
         if let Some(child) = self.0.take() {
             add(child);
@@ -126,17 +130,14 @@ impl Drop for AddOnDropChunkStream {
     }
 }
 
-impl Deref for AddOnDropChunkStream {
-    type Target = ProcessChunkStream;
+impl Stream for TrackedChildStream {
+    type Item = <ProcessChunkStream as Stream>::Item;
 
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref().unwrap() // only none after drop
-    }
-}
-
-impl DerefMut for AddOnDropChunkStream {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.as_mut().unwrap() // only none after drop
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.0.as_mut() {
+            Some(stream) => Pin::new(stream).poll_next(cx),
+            None => Poll::Ready(None),
+        }
     }
 }
 
@@ -145,6 +146,8 @@ mod tests {
     use super::*;
     use std::{process::Stdio, sync::MutexGuard};
     use tokio::process::Command;
+    use tokio_process_stream::Item;
+    use tokio_stream::StreamExt;
 
     static TEST_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(<_>::default);
 
@@ -155,11 +158,11 @@ mod tests {
     }
 
     fn clear_running() {
-        RUNNING.lock().unwrap().clear();
+        running_registry().clear();
     }
 
     fn running_len() -> usize {
-        RUNNING.lock().unwrap().len()
+        running_registry().len()
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -218,7 +221,7 @@ mod tests {
             .stderr(Stdio::null());
         let child = child.spawn().expect("spawn running child");
 
-        let tracked = AddOnDropChunkStream::from(ProcessChunkStream::from(child));
+        let tracked = TrackedChildStream::from(ProcessChunkStream::from(child));
         drop(tracked);
 
         assert_eq!(
@@ -228,6 +231,44 @@ mod tests {
         );
 
         wait().await;
+        clear_running();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn tracked_child_stream_yields_inner_process_items() {
+        let _guard = test_guard();
+        clear_running();
+
+        let mut child = Command::new("sh");
+        child
+            .arg("-c")
+            .arg("printf tracked-output")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let child = child.spawn().expect("spawn output child");
+        let mut tracked = TrackedChildStream::from(ProcessChunkStream::from(child));
+        let mut stdout = Vec::new();
+
+        while let Some(next) = tracked.next().await {
+            match next {
+                Item::Stdout(chunk) => stdout.extend_from_slice(&chunk),
+                Item::Stderr(_) => {}
+                Item::Done(status) => {
+                    assert!(status.expect("wait output child").success());
+                    break;
+                }
+            }
+        }
+        drop(tracked);
+
+        assert_eq!(stdout, b"tracked-output");
+        assert_eq!(
+            running_len(),
+            0,
+            "a completed tracked stream should not be registered on drop"
+        );
+
         clear_running();
     }
 
@@ -264,5 +305,43 @@ mod tests {
             registered_after_cancel, 1,
             "cancelling wait should not drop unfinished children from the shutdown registry"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn add_prunes_children_that_already_exited() {
+        let _guard = test_guard();
+        clear_running();
+
+        let mut exited = Command::new("sh");
+        exited
+            .arg("-c")
+            .arg("sleep 0.1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let exited = exited.spawn().expect("spawn short-lived child");
+
+        add(ProcessChunkStream::from(exited));
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let mut running = Command::new("sh");
+        running
+            .arg("-c")
+            .arg("sleep 5")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let running = running.spawn().expect("spawn running child");
+
+        add(ProcessChunkStream::from(running));
+
+        assert_eq!(
+            running_len(),
+            1,
+            "adding a child should prune any tracked children that already exited"
+        );
+
+        wait().await;
+        clear_running();
     }
 }

--- a/src/process/child.rs
+++ b/src/process/child.rs
@@ -20,9 +20,15 @@ pub fn add(mut child: ProcessChunkStream) {
     let mut running = RUNNING.lock().unwrap();
 
     // remove any that have exited already
-    running.retain_mut(|c| c.child_mut().is_some_and(|c| c.try_wait().is_err()));
+    running.retain_mut(|c| {
+        c.child_mut()
+            .is_some_and(|c| matches!(c.try_wait(), Ok(None)))
+    });
 
-    if child.child_mut().is_some_and(|c| c.try_wait().is_err()) {
+    if child
+        .child_mut()
+        .is_some_and(|c| matches!(c.try_wait(), Ok(None)))
+    {
         running.push(child);
     }
 }
@@ -96,5 +102,97 @@ impl Deref for AddOnDropChunkStream {
 impl DerefMut for AddOnDropChunkStream {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.as_mut().unwrap() // only none after drop
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{process::Stdio, sync::MutexGuard};
+    use tokio::process::Command;
+
+    static TEST_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(<_>::default);
+
+    fn test_guard() -> MutexGuard<'static, ()> {
+        TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn clear_running() {
+        RUNNING.lock().unwrap().clear();
+    }
+
+    fn running_len() -> usize {
+        RUNNING.lock().unwrap().len()
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn add_tracks_running_child() {
+        let _guard = test_guard();
+        clear_running();
+
+        let mut child = Command::new("sh");
+        child
+            .arg("-c")
+            .arg("sleep 5")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = child.spawn().expect("spawn running child");
+
+        add(ProcessChunkStream::from(child));
+
+        assert_eq!(running_len(), 1, "running child should be tracked");
+
+        wait().await;
+        clear_running();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn add_ignores_exited_child() {
+        let _guard = test_guard();
+        clear_running();
+
+        let mut child = Command::new("sh");
+        child
+            .arg("-c")
+            .arg("exit 0")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut child = child.spawn().expect("spawn exited child");
+        child.wait().await.expect("wait exited child");
+
+        add(ProcessChunkStream::from(child));
+
+        assert_eq!(running_len(), 0, "exited child should not be tracked");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn drop_of_running_stream_registers_child() {
+        let _guard = test_guard();
+        clear_running();
+
+        let mut child = Command::new("sh");
+        child
+            .arg("-c")
+            .arg("sleep 5")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = child.spawn().expect("spawn running child");
+
+        let tracked = AddOnDropChunkStream::from(ProcessChunkStream::from(child));
+        drop(tracked);
+
+        assert_eq!(
+            running_len(),
+            1,
+            "dropping a live stream should register it"
+        );
+
+        wait().await;
+        clear_running();
     }
 }

--- a/src/vmaf.rs
+++ b/src/vmaf.rs
@@ -38,7 +38,7 @@ pub fn run(
 
     let cmd_str = cmd.to_cmd_str();
     debug!("cmd `{cmd_str}`");
-    let mut vmaf = crate::process::child::AddOnDropChunkStream::from(
+    let mut vmaf = crate::process::child::TrackedChildStream::from(
         ProcessChunkStream::try_from(cmd).context("ffmpeg vmaf")?,
     );
 

--- a/src/xpsnr.rs
+++ b/src/xpsnr.rs
@@ -34,7 +34,7 @@ pub fn run(
 
     let cmd_str = cmd.to_cmd_str();
     debug!("cmd `{cmd_str}`");
-    let mut xpsnr = crate::process::child::AddOnDropChunkStream::from(
+    let mut xpsnr = crate::process::child::TrackedChildStream::from(
         ProcessChunkStream::try_from(cmd).context("ffmpeg xpsnr")?,
     );
 


### PR DESCRIPTION
## Summary

This fixes score subprocess shutdown bookkeeping so live ffmpeg children are retained for shutdown waiting, while children that have already exited are ignored.

The bug was in the liveness check used when registering score subprocesses for final shutdown. A running child returns `Ok(None)` from `try_wait()`, but the previous code treated `try_wait()` errors as the running signal. That could skip live ffmpeg processes and leave them behind after interrupted or early-terminated score runs.

## Code changes

- Centralizes child liveness checks in one helper that treats `Ok(None)` as running.
- Keeps the shutdown registry pruned so exited children are not retained.
- Makes `wait()` cancellation-safe by re-registering unfinished children if the wait future is dropped before all children exit.
- When the interrupt signal is received, explicitly kills and reaps tracked children before discarding them so abort cleanup does not leave live or zombie score subprocesses behind.
- Replaces the previous deref-based drop wrapper with `TrackedChildStream`, a stream wrapper that forwards the inner process stream and registers the child on early drop.
- Splits the child wait loop from the outer shutdown wrapper so signal handling stays in `wait()` and the inner wait behavior can be tested directly.

## Why the refactors are part of this fix

The original bug came from lifecycle ambiguity: process ownership, liveness detection, stream polling, drop behavior, global registration, shutdown waiting, logging, and Ctrl-C handling were all coupled together.

The refactors are intentionally scoped to the process lifecycle path so the fix is harder to regress:

- The liveness helper makes the corrected `try_wait()` interpretation reusable instead of duplicating subtle process-state logic.
- `TrackedChildStream` avoids making a lifecycle-sensitive wrapper pretend to be a `ProcessChunkStream` through `Deref`; callers poll it as a stream directly.
- The registry owner makes cancellation behavior explicit: unfinished children go back into the registry instead of being lost when `wait()` is cancelled.
- The abort cleanup helper keeps the Ctrl-C path explicit about both parts of process cleanup: terminate children that are still running, then wait so the OS can reap them.
- The inner wait helper keeps the slow-wait behavior testable without mixing it with Ctrl-C wiring.

## Tests added

- Running children are registered for shutdown waiting.
- Already-exited children are not registered.
- Dropping a live tracked stream registers the child.
- A completed tracked stream forwards stdout items and does not register itself on drop.
- Adding a new child prunes previously tracked children that have since exited.
- Cancelling `wait()` while a child is still running keeps that child registered for a later shutdown wait.
- The inner wait helper waits for supplied children to exit.
- The slow-wait callback fires once after the configured threshold.

## Impact

Interrupted or early-terminated score runs should no longer leave live ffmpeg score subprocesses behind. The shutdown path should also be easier for maintainers to audit because process ownership and liveness decisions are named and covered by targeted tests.
