### PR TITLE
Fix graceful shutdown of ffmpeg child processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased (0.11.4)
 * Fix "sample x/n ..." log formatting.
+* Fix graceful shutdown of ffmpeg child processes.
 
 # v0.11.3
 * Add sample-encode support for computing both XPSNR **and** VMAF using `--xpsnr --and-vmaf`.

--- a/src/process/child.rs
+++ b/src/process/child.rs
@@ -20,9 +20,9 @@ pub fn add(mut child: ProcessChunkStream) {
     let mut running = RUNNING.lock().unwrap();
 
     // remove any that have exited already
-    running.retain_mut(|c| c.child_mut().is_some_and(|c| c.try_wait().is_err()));
+    running.retain_mut(|c| !c.exited());
 
-    if child.child_mut().is_some_and(|c| c.try_wait().is_err()) {
+    if !child.exited() {
         running.push(child);
     }
 }
@@ -96,5 +96,19 @@ impl Deref for AddOnDropChunkStream {
 impl DerefMut for AddOnDropChunkStream {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.as_mut().unwrap() // only none after drop
+    }
+}
+
+trait Exited {
+    /// Returns true if the child process has exited.
+    fn exited(&mut self) -> bool;
+}
+
+impl Exited for ProcessChunkStream {
+    fn exited(&mut self) -> bool {
+        let Some(child) = self.child_mut() else {
+            return true; // no child process
+        };
+        child.try_wait().is_ok_and(|s| s.is_some())
     }
 }


### PR DESCRIPTION
Previously `Child::try_wait` results of `Ok(None)` were incorrectly interpreted as meaning the process had exited.