### PR TITLE
Add crf-search --stdout-format json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+* Add crf-search `--stdout-format json` outputting newline delimited json messages,
+  see [stdout-format-json.md](stdout-format-json.md).
+* Add `type`, `crf` & `from_cache` keys to the sample-encode `--stdout-format json` output.
+
 # v0.11.4
 * Fix "sample x/n ..." log formatting.
 * Fix graceful shutdown of ffmpeg child processes.

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -32,7 +32,7 @@ const BAR_LEN: u64 = 1024 * 1024 * 1024;
 #[group(skip)]
 pub struct Args {
     #[clap(flatten)]
-    pub search: crf_search::Args,
+    pub search: crf_search::SearchArgs,
 
     #[clap(flatten)]
     pub encode: args::EncodeToOutput,

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -145,6 +145,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
                     result.print_attempt(&bar, sample, Some(crf))
                 }
             }
+            Ok(crf_search::Update::SampleEncoded(_)) => {}
             Ok(crf_search::Update::RunResult(result)) => {
                 if verbose
                     .log_level()
@@ -192,4 +193,13 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
         &bar,
     )
     .await
+}
+
+/// crf-search json output is not currently available in auto-encode.
+#[test]
+fn stdout_format_unsupported() {
+    assert!(
+        Args::try_parse_from(["auto-encode", "-i", "vid.mkv", "--stdout-format", "json"]).is_err()
+    );
+    assert!(Args::try_parse_from(["auto-encode", "-i", "vid.mkv"]).is_ok());
 }

--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -145,7 +145,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
                     result.print_attempt(&bar, sample, Some(crf))
                 }
             }
-            Ok(crf_search::Update::SampleEncoded(_)) => {}
+            Ok(crf_search::Update::SampleEncodeDone(_)) => {}
             Ok(crf_search::Update::RunResult(result)) => {
                 if verbose
                     .log_level()

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -37,6 +37,14 @@ const DEFAULT_MIN_VMAF: f32 = 95.0;
 #[group(skip)]
 pub struct Args {
     #[clap(flatten)]
+    pub search: SearchArgs,
+}
+
+/// Search args shared with auto-encode.
+#[derive(Parser)]
+#[group(skip)]
+pub struct SearchArgs {
+    #[clap(flatten)]
     pub args: args::Encode,
 
     /// Desired min VMAF score to deliver.
@@ -112,7 +120,7 @@ pub struct Args {
     pub verbose: clap_verbosity_flag::Verbosity,
 }
 
-impl Args {
+impl SearchArgs {
     pub fn min_score(&self) -> f32 {
         self.min_vmaf.or(self.min_xpsnr).unwrap_or(DEFAULT_MIN_VMAF)
     }
@@ -131,8 +139,8 @@ impl Args {
     }
 }
 
-pub async fn crf_search(mut args: Args) -> anyhow::Result<()> {
-    args.validate()?;
+pub async fn crf_search(Args { mut search }: Args) -> anyhow::Result<()> {
+    search.validate()?;
 
     let bar = ProgressBar::new(BAR_LEN).with_style(
         ProgressStyle::default_bar()
@@ -141,18 +149,19 @@ pub async fn crf_search(mut args: Args) -> anyhow::Result<()> {
     );
     bar.enable_steady_tick(Duration::from_millis(100));
 
-    let probe = ffprobe::probe(&args.args.input);
+    let probe = ffprobe::probe(&search.args.input);
     let input_is_image = probe.is_image;
-    args.sample
-        .set_extension_from_input(&args.args.input, &args.args.encoder, &probe);
+    search
+        .sample
+        .set_extension_from_input(&search.args.input, &search.args.encoder, &probe);
 
-    let min_score = args.min_score();
-    let max_encoded_percent = args.max_encoded_percent;
-    let thorough = args.thorough;
-    let enc_args = args.args.clone();
-    let verbose = args.verbose;
+    let min_score = search.min_score();
+    let max_encoded_percent = search.max_encoded_percent;
+    let thorough = search.thorough;
+    let enc_args = search.args.clone();
+    let verbose = search.verbose;
 
-    let mut run = pin!(run(args, probe.into()));
+    let mut run = pin!(run(search, probe.into()));
     while let Some(update) = run.next().await {
         let update = update.inspect_err(|e| {
             if let Error::NoGoodCrf { last } = e {
@@ -209,7 +218,7 @@ pub async fn crf_search(mut args: Args) -> anyhow::Result<()> {
                         style(enc_args.encode_hint(best.crf)).dim().italic(),
                     );
                 }
-                StdoutFormat::Human.print_result(&best, input_is_image);
+                best.print_result_human(input_is_image);
                 return Ok(());
             }
         }
@@ -218,7 +227,7 @@ pub async fn crf_search(mut args: Args) -> anyhow::Result<()> {
 }
 
 pub fn run(
-    Args {
+    SearchArgs {
         args,
         min_vmaf,
         min_xpsnr,
@@ -234,7 +243,7 @@ pub fn run(
         score,
         xpsnr,
         verbose: _,
-    }: Args,
+    }: SearchArgs,
     input_probe: Arc<Ffprobe>,
 ) -> impl Stream<Item = Result<Update, Error>> {
     async_stream::try_stream! {
@@ -427,33 +436,22 @@ impl Sample {
             "{crf_label} {crf} {score_label} {score:.2} {open}{percent}{close}{cache_msg}"
         ));
     }
-}
 
-#[derive(Debug, Clone, Copy, clap::ValueEnum)]
-pub enum StdoutFormat {
-    Human,
-}
-
-impl StdoutFormat {
-    fn print_result(self, sample: &Sample, image: bool) {
-        match self {
-            Self::Human => {
-                let crf = style(TerseF32(sample.crf)).bold().green();
-                let enc = &sample.enc;
-                let score = style(enc.single_score()).bold().green();
-                let score_kind = enc.single_score_kind();
-                let size = style(HumanBytes(enc.predicted_encode_size)).bold().green();
-                let percent = style!("{}%", enc.encode_percent.round()).bold().green();
-                let time = style(HumanDuration(enc.predicted_encode_time)).bold();
-                let enc_description = match image {
-                    true => "image",
-                    false => "video stream",
-                };
-                println!(
-                    "crf {crf} {score_kind} {score:.2} predicted {enc_description} size {size} ({percent}) taking {time}"
-                );
-            }
-        }
+    pub fn print_result_human(&self, image: bool) {
+        let crf = style(TerseF32(self.crf)).bold().green();
+        let enc = &self.enc;
+        let score = style(enc.single_score()).bold().green();
+        let score_kind = enc.single_score_kind();
+        let size = style(HumanBytes(enc.predicted_encode_size)).bold().green();
+        let percent = style!("{}%", enc.encode_percent.round()).bold().green();
+        let time = style(HumanDuration(enc.predicted_encode_time)).bold();
+        let enc_description = match image {
+            true => "image",
+            false => "video stream",
+        };
+        println!(
+            "crf {crf} {score_kind} {score:.2} predicted {enc_description} size {size} ({percent}) taking {time}"
+        );
     }
 }
 

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -5,7 +5,7 @@ pub use err::Error;
 use crate::{
     command::{
         PROGRESS_CHARS, args,
-        sample_encode::{self, Work},
+        sample_encode::{self, StdoutFormat, Work},
     },
     console_ext::style,
     ffprobe::{self, Ffprobe},
@@ -38,6 +38,12 @@ const DEFAULT_MIN_VMAF: f32 = 95.0;
 pub struct Args {
     #[clap(flatten)]
     pub search: SearchArgs,
+
+    /// Stdout message format `human` or `json`.
+    ///
+    /// See <https://github.com/alexheretic/ab-av1/blob/main/stdout-format-json.md>
+    #[arg(long, value_enum, default_value_t = StdoutFormat::Human)]
+    pub stdout_format: StdoutFormat,
 }
 
 /// Search args shared with auto-encode.
@@ -139,7 +145,12 @@ impl SearchArgs {
     }
 }
 
-pub async fn crf_search(Args { mut search }: Args) -> anyhow::Result<()> {
+pub async fn crf_search(
+    Args {
+        mut search,
+        stdout_format,
+    }: Args,
+) -> anyhow::Result<()> {
     search.validate()?;
 
     let bar = ProgressBar::new(BAR_LEN).with_style(
@@ -166,6 +177,10 @@ pub async fn crf_search(Args { mut search }: Args) -> anyhow::Result<()> {
         let update = update.inspect_err(|e| {
             if let Error::NoGoodCrf { last } = e {
                 last.print_attempt(&bar, min_score, max_encoded_percent);
+                if let StdoutFormat::Json = stdout_format {
+                    println!("{}", last.attempt_json());
+                    println!("{}", error_json(e));
+                }
             }
         })?;
         match update {
@@ -207,7 +222,17 @@ pub async fn crf_search(Args { mut search }: Args) -> anyhow::Result<()> {
                     result.print_attempt(&bar, sample, Some(crf))
                 }
             }
-            Update::RunResult(result) => result.print_attempt(&bar, min_score, max_encoded_percent),
+            Update::SampleEncoded(sample) => {
+                if let StdoutFormat::Json = stdout_format {
+                    println!("{}", sample.enc.sample_encode_done_json(sample.crf));
+                }
+            }
+            Update::RunResult(result) => {
+                result.print_attempt(&bar, min_score, max_encoded_percent);
+                if let StdoutFormat::Json = stdout_format {
+                    println!("{}", result.attempt_json());
+                }
+            }
             Update::Done(best) => {
                 info!("crf {} successful", best.crf);
                 bar.finish_with_message("");
@@ -218,7 +243,10 @@ pub async fn crf_search(Args { mut search }: Args) -> anyhow::Result<()> {
                         style(enc_args.encode_hint(best.crf)).dim().italic(),
                     );
                 }
-                best.print_result_human(input_is_image);
+                match stdout_format {
+                    StdoutFormat::Human => best.print_result_human(input_is_image),
+                    StdoutFormat::Json => println!("{}", best.done_json()),
+                }
                 return Ok(());
             }
         }
@@ -323,6 +351,7 @@ pub fn run(
             };
             let score = sample.enc.single_score();
             crf_attempts.push(sample.clone());
+            yield Update::SampleEncoded(sample.clone());
             let sample_small_enough = sample.enc.encode_percent <= max_encoded_percent as _;
 
             if score > min_score {
@@ -453,6 +482,87 @@ impl Sample {
             "crf {crf} {score_kind} {score:.2} predicted {enc_description} size {size} ({percent}) taking {time}"
         );
     }
+
+    /// `crf-search-attempt` json message, see _stdout-format-json.md_.
+    pub fn attempt_json(&self) -> serde_json::Value {
+        let mut json = serde_json::json!({
+            "type": "crf-search-attempt",
+            "crf": self.crf,
+            "from_cache": self.enc.from_cache,
+            "predicted_encode_percent": self.enc.encode_percent,
+        });
+        if let Some(score) = self.enc.vmaf_score {
+            json["vmaf"] = score.into();
+        }
+        if let Some(score) = self.enc.xpsnr_score {
+            json["xpsnr"] = score.into();
+        }
+        json
+    }
+
+    /// `crf-search-done` json message, see _stdout-format-json.md_.
+    pub fn done_json(&self) -> serde_json::Value {
+        let mut json = self.enc.sample_encode_done_json(self.crf);
+        json["type"] = "crf-search-done".into();
+        json
+    }
+}
+
+/// `crf-search-error` json message, see _stdout-format-json.md_.
+fn error_json(err: &Error) -> serde_json::Value {
+    serde_json::json!({
+        "type": "crf-search-error",
+        "message": err.to_string(),
+    })
+}
+
+#[cfg(test)]
+fn test_sample() -> Sample {
+    Sample {
+        enc: sample_encode::Output {
+            vmaf_score: Some(95.5),
+            xpsnr_score: None,
+            predicted_encode_size: 38889644,
+            encode_percent: 41.25,
+            predicted_encode_time: Duration::from_secs(1560),
+            from_cache: false,
+        },
+        crf: 34.0,
+        q: 34,
+    }
+}
+
+#[test]
+fn attempt_json_message() {
+    assert_eq!(
+        test_sample().attempt_json().to_string(),
+        r#"{"crf":34.0,"from_cache":false,"predicted_encode_percent":41.25,"type":"crf-search-attempt","vmaf":95.5}"#
+    );
+}
+
+#[test]
+fn done_json_message() {
+    assert_eq!(
+        test_sample().done_json().to_string(),
+        r#"{"crf":34.0,"from_cache":false,"predicted_encode_percent":41.25,"predicted_encode_seconds":1560.0,"predicted_encode_size":38889644,"type":"crf-search-done","vmaf":95.5}"#
+    );
+}
+
+#[test]
+fn error_json_message() {
+    let err = Error::NoGoodCrf {
+        last: test_sample(),
+    };
+    assert_eq!(
+        error_json(&err).to_string(),
+        r#"{"message":"Failed to find a suitable crf","type":"crf-search-error"}"#
+    );
+}
+
+#[test]
+fn parse_stdout_format() {
+    Args::try_parse_from(["crf-search", "-i", "vid.mkv", "--stdout-format", "json"])
+        .expect("--stdout-format json should parse");
 }
 
 /// Produce a q value between given samples using vmaf score linear interpolation
@@ -586,6 +696,8 @@ pub enum Update {
         sample: u64,
         result: sample_encode::EncodeResult,
     },
+    /// Sample encode of a crf attempt completed, emitted for every attempt.
+    SampleEncoded(Sample),
     /// Run result (excludes successful final runs)
     RunResult(Sample),
     Done(Sample),

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -222,7 +222,7 @@ pub async fn crf_search(
                     result.print_attempt(&bar, sample, Some(crf))
                 }
             }
-            Update::SampleEncoded(sample) => {
+            Update::SampleEncodeDone(sample) => {
                 if let StdoutFormat::Json = stdout_format {
                     println!("{}", sample.enc.sample_encode_done_json(sample.crf));
                 }
@@ -351,7 +351,7 @@ pub fn run(
             };
             let score = sample.enc.single_score();
             crf_attempts.push(sample.clone());
-            yield Update::SampleEncoded(sample.clone());
+            yield Update::SampleEncodeDone(sample.clone());
             let sample_small_enough = sample.enc.encode_percent <= max_encoded_percent as _;
 
             if score > min_score {
@@ -697,7 +697,7 @@ pub enum Update {
         result: sample_encode::EncodeResult,
     },
     /// Sample encode of a crf attempt completed, emitted for every attempt.
-    SampleEncoded(Sample),
+    SampleEncodeDone(Sample),
     /// Run result (excludes successful final runs)
     RunResult(Sample),
     Done(Sample),

--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -178,7 +178,6 @@ pub async fn crf_search(
             if let Error::NoGoodCrf { last } = e {
                 last.print_attempt(&bar, min_score, max_encoded_percent);
                 if let StdoutFormat::Json = stdout_format {
-                    println!("{}", last.attempt_json());
                     println!("{}", error_json(e));
                 }
             }
@@ -227,12 +226,7 @@ pub async fn crf_search(
                     println!("{}", sample.enc.sample_encode_done_json(sample.crf));
                 }
             }
-            Update::RunResult(result) => {
-                result.print_attempt(&bar, min_score, max_encoded_percent);
-                if let StdoutFormat::Json = stdout_format {
-                    println!("{}", result.attempt_json());
-                }
-            }
+            Update::RunResult(result) => result.print_attempt(&bar, min_score, max_encoded_percent),
             Update::Done(best) => {
                 info!("crf {} successful", best.crf);
                 bar.finish_with_message("");
@@ -483,23 +477,6 @@ impl Sample {
         );
     }
 
-    /// `crf-search-attempt` json message, see _stdout-format-json.md_.
-    pub fn attempt_json(&self) -> serde_json::Value {
-        let mut json = serde_json::json!({
-            "type": "crf-search-attempt",
-            "crf": self.crf,
-            "from_cache": self.enc.from_cache,
-            "predicted_encode_percent": self.enc.encode_percent,
-        });
-        if let Some(score) = self.enc.vmaf_score {
-            json["vmaf"] = score.into();
-        }
-        if let Some(score) = self.enc.xpsnr_score {
-            json["xpsnr"] = score.into();
-        }
-        json
-    }
-
     /// `crf-search-done` json message, see _stdout-format-json.md_.
     pub fn done_json(&self) -> serde_json::Value {
         let mut json = self.enc.sample_encode_done_json(self.crf);
@@ -530,14 +507,6 @@ fn test_sample() -> Sample {
         crf: 34.0,
         q: 34,
     }
-}
-
-#[test]
-fn attempt_json_message() {
-    assert_eq!(
-        test_sample().attempt_json().to_string(),
-        r#"{"crf":34.0,"from_cache":false,"predicted_encode_percent":41.25,"type":"crf-search-attempt","vmaf":95.5}"#
-    );
 }
 
 #[test]

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -62,6 +62,8 @@ pub struct Args {
     pub cache: bool,
 
     /// Stdout message format `human` or `json`.
+    ///
+    /// See <https://github.com/alexheretic/ab-av1/blob/main/stdout-format-json.md>
     #[arg(long, value_enum, default_value_t = StdoutFormat::Human)]
     pub stdout_format: StdoutFormat,
 
@@ -132,7 +134,7 @@ pub async fn sample_encode(mut args: Args) -> anyhow::Result<()> {
                         style(enc_args.encode_hint(crf)).dim().italic(),
                     );
                 }
-                stdout_fmt.print_result(&output, input_is_image);
+                stdout_fmt.print_result(&output, crf, input_is_image);
             }
         }
     }
@@ -696,20 +698,17 @@ pub enum StdoutFormat {
 }
 
 impl StdoutFormat {
-    fn print_result(
-        self,
-        Output {
-            vmaf_score,
-            xpsnr_score,
-            predicted_encode_size,
-            encode_percent,
-            predicted_encode_time,
-            from_cache: _,
-        }: &Output,
-        image: bool,
-    ) {
+    fn print_result(self, output: &Output, crf: f32, image: bool) {
         match self {
             Self::Human => {
+                let Output {
+                    vmaf_score,
+                    xpsnr_score,
+                    predicted_encode_size,
+                    encode_percent,
+                    predicted_encode_time,
+                    from_cache: _,
+                } = output;
                 let vmaf_fmt = match *vmaf_score {
                     None => format_args!(""),
                     Some(s) => match s {
@@ -742,20 +741,7 @@ impl StdoutFormat {
                     "{vmaf_fmt}{xpsnr_fmt}predicted {enc_description} size {size} ({percent}) taking {time}"
                 );
             }
-            Self::Json => {
-                let mut json = serde_json::json!({
-                    "predicted_encode_size": predicted_encode_size,
-                    "predicted_encode_percent": encode_percent,
-                    "predicted_encode_seconds": predicted_encode_time.as_secs_f64(),
-                });
-                if let Some(score) = *vmaf_score {
-                    json["vmaf"] = score.into();
-                }
-                if let Some(score) = *xpsnr_score {
-                    json["xpsnr"] = score.into();
-                }
-                println!("{json}");
-            }
+            Self::Json => println!("{}", output.sample_encode_done_json(crf)),
         }
     }
 }
@@ -794,6 +780,55 @@ impl Output {
             _ => ScoreKind::Xpsnr,
         }
     }
+
+    /// `sample-encode-done` json message, see _stdout-format-json.md_.
+    pub fn sample_encode_done_json(&self, crf: f32) -> serde_json::Value {
+        let mut json = serde_json::json!({
+            "type": "sample-encode-done",
+            "crf": crf,
+            "from_cache": self.from_cache,
+            "predicted_encode_size": self.predicted_encode_size,
+            "predicted_encode_percent": self.encode_percent,
+            "predicted_encode_seconds": self.predicted_encode_time.as_secs_f64(),
+        });
+        if let Some(score) = self.vmaf_score {
+            json["vmaf"] = score.into();
+        }
+        if let Some(score) = self.xpsnr_score {
+            json["xpsnr"] = score.into();
+        }
+        json
+    }
+}
+
+#[test]
+fn sample_encode_done_json_message() {
+    let mut output = Output {
+        vmaf_score: Some(95.5),
+        xpsnr_score: None,
+        predicted_encode_size: 38889644,
+        encode_percent: 41.25,
+        predicted_encode_time: Duration::from_secs(1560),
+        from_cache: false,
+    };
+    assert_eq!(
+        output.sample_encode_done_json(34.0).to_string(),
+        r#"{"crf":34.0,"from_cache":false,"predicted_encode_percent":41.25,"predicted_encode_seconds":1560.0,"predicted_encode_size":38889644,"type":"sample-encode-done","vmaf":95.5}"#
+    );
+
+    output.vmaf_score = None;
+    output.xpsnr_score = Some(41.5);
+    output.from_cache = true;
+    assert_eq!(
+        output.sample_encode_done_json(28.25).to_string(),
+        r#"{"crf":28.25,"from_cache":true,"predicted_encode_percent":41.25,"predicted_encode_seconds":1560.0,"predicted_encode_size":38889644,"type":"sample-encode-done","xpsnr":41.5}"#
+    );
+
+    output.vmaf_score = Some(95.5);
+    assert_eq!(
+        output.sample_encode_done_json(28.25).to_string(),
+        r#"{"crf":28.25,"from_cache":true,"predicted_encode_percent":41.25,"predicted_encode_seconds":1560.0,"predicted_encode_size":38889644,"type":"sample-encode-done","vmaf":95.5,"xpsnr":41.5}"#
+    );
 }
 
 /// Kinds of sample-encode work.

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ impl Command {
     fn keep_temp_files(&self) -> bool {
         match self {
             Self::SampleEncode(args) => args.sample.keep,
-            Self::CrfSearch(args) => args.sample.keep,
+            Self::CrfSearch(args) => args.search.sample.keep,
             Self::AutoEncode(args) => args.search.sample.keep,
             _ => false,
         }

--- a/stdout-format-json.md
+++ b/stdout-format-json.md
@@ -1,22 +1,115 @@
 # Messages output when using `--stdout-format json`
 
-## sample-encode
-Single json emitted after sample encoding has finished.
+Commands supporting `--stdout-format json` write newline-delimited JSON ([NDJSON](https://github.com/ndjson/ndjson-spec)) to stdout: one object per line, each with a `type` key identifying the message kind. Progress bars, logs & hints go to stderr only, so stdout is parseable line by line.
+
+Supported by: `sample-encode`, `crf-search`.
+
+Notes:
+* Key order is not significant (currently alphabetical, so `type` is typically last).
+* Later versions may add keys & message kinds, consumers should ignore unknown ones.
+* Failures print an `Error: ...` line to stderr and exit non-zero, in json mode too. The only failure also reported as json is a failed crf-search, see [`crf-search-error`](#crf-search-error).
+
+## `sample-encode-done`
+Emitted after all samples of a sample encode run are encoded & scored. `sample-encode` emits one at the end of the run, `crf-search` one per crf attempt.
 
 Field | Description | Type/Units
 ---|---|---
+`type` | `"sample-encode-done"` | string
+`crf` | Encoder crf used | float
+`from_cache` | All sample results were read from the cache | bool
 `predicted_encode_percent` | Predicted output encode size percentage vs input | float
 `predicted_encode_seconds` | Predicted output encode time in seconds | float
 `predicted_encode_size` | Predicted output encode size in bytes | uint
-`vmaf` | VMAF score (present when requested (default)) | float
-`xpsnr` | XPSNR score (present when requested) | float
+`vmaf` | Mean sample VMAF score (present when requested (default)) | float
+`xpsnr` | Mean sample XPSNR score (present when requested) | float
 
 ### Example
 ```json
-{
-  "predicted_encode_percent": 41.01556024884758,
-  "predicted_encode_seconds": 33,
-  "predicted_encode_size": 38889644,
-  "vmaf": 95.13105773925781
-}
+{"crf":29.25,"from_cache":false,"predicted_encode_percent":14.819840772420237,"predicted_encode_seconds":12.0,"predicted_encode_size":73692619,"type":"sample-encode-done","vmaf":95.37376403808594}
+```
+
+Note: In ≤ v0.11.4 `sample-encode` emitted this object without the `type`, `crf` & `from_cache` keys.
+
+## `crf-search-attempt`
+Emitted after each crf attempt that did not successfully end the search, like the human `- crf 34 VMAF 95.13 (41%)` line. Follows the attempt's `sample-encode-done`, which carries the full predictions.
+
+Field | Description | Type/Units
+---|---|---
+`type` | `"crf-search-attempt"` | string
+`crf` | Attempted crf | float
+`from_cache` | All sample results were read from the cache | bool
+`predicted_encode_percent` | Predicted output encode size percentage vs input | float
+`vmaf` | Mean sample VMAF score (present when requested (default)) | float
+`xpsnr` | Mean sample XPSNR score (present when requested) | float
+
+### Example
+```json
+{"crf":29.25,"from_cache":false,"predicted_encode_percent":14.819840772420237,"type":"crf-search-attempt","vmaf":95.37376403808594}
+```
+
+## `crf-search-done`
+Emitted when the search ends successfully, like the final human result line. A successful final attempt gets no `crf-search-attempt`.
+
+Note: The best crf may have been decided by an earlier attempt, in which case this message repeats that attempt's values and is not adjacent to its `sample-encode-done`.
+
+Field | Description | Type/Units
+---|---|---
+`type` | `"crf-search-done"` | string
+`crf` | Best crf found | float
+`from_cache` | All sample results were read from the cache | bool
+`predicted_encode_percent` | Predicted output encode size percentage vs input | float
+`predicted_encode_seconds` | Predicted output encode time in seconds | float
+`predicted_encode_size` | Predicted output encode size in bytes | uint
+`vmaf` | Mean sample VMAF score (present when requested (default)) | float
+`xpsnr` | Mean sample XPSNR score (present when requested) | float
+
+### Example
+```json
+{"crf":29.75,"from_cache":false,"predicted_encode_percent":13.785497397240093,"predicted_encode_seconds":13.0,"predicted_encode_size":68549279,"type":"crf-search-done","vmaf":95.16242980957031}
+```
+
+## `crf-search-error`
+Emitted when the search fails to find a crf satisfying the min score & max encoded percent. Follows the failing attempt's `sample-encode-done` & `crf-search-attempt`. As in human mode, `Error: Failed to find a suitable crf` goes to stderr and the exit code is non-zero.
+
+Field | Description | Type/Units
+---|---|---
+`type` | `"crf-search-error"` | string
+`message` | Failure description | string
+
+### Example
+```json
+{"message":"Failed to find a suitable crf","type":"crf-search-error"}
+```
+
+## `sample-encode` output
+A single `sample-encode-done`.
+
+## `crf-search` output
+`sample-encode-done` + `crf-search-attempt` per unsuccessful attempt, ending with `crf-search-done` (exit 0) or `crf-search-error` (non-zero exit).
+
+Guarantees:
+* Exactly one `sample-encode-done` per crf attempted.
+* The final line is a `crf-search-done` or `crf-search-error`. Other errors (e.g. invalid input) end the stream with no json message: stderr `Error:` line & non-zero exit only.
+
+### Example: successful search
+```json
+{"crf":37.5,"from_cache":false,"predicted_encode_percent":3.9154531401777755,"predicted_encode_seconds":9.0,"predicted_encode_size":19469845,"type":"sample-encode-done","vmaf":90.38392639160156}
+{"crf":37.5,"from_cache":false,"predicted_encode_percent":3.9154531401777755,"type":"crf-search-attempt","vmaf":90.38392639160156}
+{"crf":18.0,"from_cache":false,"predicted_encode_percent":58.12225504159517,"predicted_encode_seconds":16.0,"predicted_encode_size":289016681,"type":"sample-encode-done","vmaf":98.99139404296875}
+{"crf":18.0,"from_cache":false,"predicted_encode_percent":58.12225504159517,"type":"crf-search-attempt","vmaf":98.99139404296875}
+{"crf":27.0,"from_cache":false,"predicted_encode_percent":20.79908059385195,"predicted_encode_seconds":13.0,"predicted_encode_size":103424776,"type":"sample-encode-done","vmaf":96.34620666503906}
+{"crf":27.0,"from_cache":false,"predicted_encode_percent":20.79908059385195,"type":"crf-search-attempt","vmaf":96.34620666503906}
+{"crf":29.25,"from_cache":false,"predicted_encode_percent":14.819840772420237,"predicted_encode_seconds":12.0,"predicted_encode_size":73692619,"type":"sample-encode-done","vmaf":95.37376403808594}
+{"crf":29.25,"from_cache":false,"predicted_encode_percent":14.819840772420237,"type":"crf-search-attempt","vmaf":95.37376403808594}
+{"crf":29.75,"from_cache":false,"predicted_encode_percent":13.785497397240093,"predicted_encode_seconds":13.0,"predicted_encode_size":68549279,"type":"sample-encode-done","vmaf":95.16242980957031}
+{"crf":29.75,"from_cache":false,"predicted_encode_percent":13.785497397240093,"predicted_encode_seconds":13.0,"predicted_encode_size":68549279,"type":"crf-search-done","vmaf":95.16242980957031}
+```
+
+### Example: failed search
+```json
+{"crf":37.5,"from_cache":false,"predicted_encode_percent":3.9154531401777755,"predicted_encode_seconds":10.0,"predicted_encode_size":19469845,"type":"sample-encode-done","vmaf":90.38392639160156}
+{"crf":37.5,"from_cache":false,"predicted_encode_percent":3.9154531401777755,"type":"crf-search-attempt","vmaf":90.38392639160156}
+{"crf":18.0,"from_cache":false,"predicted_encode_percent":58.12225504159517,"predicted_encode_seconds":18.0,"predicted_encode_size":289016681,"type":"sample-encode-done","vmaf":98.99139404296875}
+{"crf":18.0,"from_cache":false,"predicted_encode_percent":58.12225504159517,"type":"crf-search-attempt","vmaf":98.99139404296875}
+{"message":"Failed to find a suitable crf","type":"crf-search-error"}
 ```

--- a/stdout-format-json.md
+++ b/stdout-format-json.md
@@ -95,20 +95,12 @@ Guarantees:
 ```json
 {"crf":37.5,"from_cache":false,"predicted_encode_percent":3.9154531401777755,"predicted_encode_seconds":9.0,"predicted_encode_size":19469845,"type":"sample-encode-done","vmaf":90.38392639160156}
 {"crf":37.5,"from_cache":false,"predicted_encode_percent":3.9154531401777755,"type":"crf-search-attempt","vmaf":90.38392639160156}
-{"crf":18.0,"from_cache":false,"predicted_encode_percent":58.12225504159517,"predicted_encode_seconds":16.0,"predicted_encode_size":289016681,"type":"sample-encode-done","vmaf":98.99139404296875}
-{"crf":18.0,"from_cache":false,"predicted_encode_percent":58.12225504159517,"type":"crf-search-attempt","vmaf":98.99139404296875}
-{"crf":27.0,"from_cache":false,"predicted_encode_percent":20.79908059385195,"predicted_encode_seconds":13.0,"predicted_encode_size":103424776,"type":"sample-encode-done","vmaf":96.34620666503906}
-{"crf":27.0,"from_cache":false,"predicted_encode_percent":20.79908059385195,"type":"crf-search-attempt","vmaf":96.34620666503906}
-{"crf":29.25,"from_cache":false,"predicted_encode_percent":14.819840772420237,"predicted_encode_seconds":12.0,"predicted_encode_size":73692619,"type":"sample-encode-done","vmaf":95.37376403808594}
-{"crf":29.25,"from_cache":false,"predicted_encode_percent":14.819840772420237,"type":"crf-search-attempt","vmaf":95.37376403808594}
 {"crf":29.75,"from_cache":false,"predicted_encode_percent":13.785497397240093,"predicted_encode_seconds":13.0,"predicted_encode_size":68549279,"type":"sample-encode-done","vmaf":95.16242980957031}
 {"crf":29.75,"from_cache":false,"predicted_encode_percent":13.785497397240093,"predicted_encode_seconds":13.0,"predicted_encode_size":68549279,"type":"crf-search-done","vmaf":95.16242980957031}
 ```
 
 ### Example: failed search
 ```json
-{"crf":37.5,"from_cache":false,"predicted_encode_percent":3.9154531401777755,"predicted_encode_seconds":10.0,"predicted_encode_size":19469845,"type":"sample-encode-done","vmaf":90.38392639160156}
-{"crf":37.5,"from_cache":false,"predicted_encode_percent":3.9154531401777755,"type":"crf-search-attempt","vmaf":90.38392639160156}
 {"crf":18.0,"from_cache":false,"predicted_encode_percent":58.12225504159517,"predicted_encode_seconds":18.0,"predicted_encode_size":289016681,"type":"sample-encode-done","vmaf":98.99139404296875}
 {"crf":18.0,"from_cache":false,"predicted_encode_percent":58.12225504159517,"type":"crf-search-attempt","vmaf":98.99139404296875}
 {"message":"Failed to find a suitable crf","type":"crf-search-error"}

--- a/stdout-format-json.md
+++ b/stdout-format-json.md
@@ -89,7 +89,7 @@ A single `sample-encode-done`.
 
 Guarantees:
 * Exactly one `sample-encode-done` per crf attempted.
-* The final line is a `crf-search-done` or `crf-search-error`. Other errors (e.g. invalid input) end the stream with no json message: stderr `Error:` line & non-zero exit only.
+* The final line is a `crf-search-done` or `crf-search-error`. Other errors (e.g. invalid input) end the stream with no final json message: stderr `Error:` line & non-zero exit only.
 
 ### Example: successful search
 ```json

--- a/stdout-format-json.md
+++ b/stdout-format-json.md
@@ -30,25 +30,8 @@ Field | Description | Type/Units
 
 Note: In ≤ v0.11.4 `sample-encode` emitted this object without the `type`, `crf` & `from_cache` keys.
 
-## `crf-search-attempt`
-Emitted after each crf attempt that did not successfully end the search, like the human `- crf 34 VMAF 95.13 (41%)` line. Follows the attempt's `sample-encode-done`, which carries the full predictions.
-
-Field | Description | Type/Units
----|---|---
-`type` | `"crf-search-attempt"` | string
-`crf` | Attempted crf | float
-`from_cache` | All sample results were read from the cache | bool
-`predicted_encode_percent` | Predicted output encode size percentage vs input | float
-`vmaf` | Mean sample VMAF score (present when requested (default)) | float
-`xpsnr` | Mean sample XPSNR score (present when requested) | float
-
-### Example
-```json
-{"crf":29.25,"from_cache":false,"predicted_encode_percent":14.819840772420237,"type":"crf-search-attempt","vmaf":95.37376403808594}
-```
-
 ## `crf-search-done`
-Emitted when the search ends successfully, like the final human result line. A successful final attempt gets no `crf-search-attempt`.
+Emitted when the search ends successfully, like the final human result line.
 
 Note: The best crf may have been decided by an earlier attempt, in which case this message repeats that attempt's values and is not adjacent to its `sample-encode-done`.
 
@@ -69,7 +52,7 @@ Field | Description | Type/Units
 ```
 
 ## `crf-search-error`
-Emitted when the search fails to find a crf satisfying the min score & max encoded percent. Follows the failing attempt's `sample-encode-done` & `crf-search-attempt`. As in human mode, `Error: Failed to find a suitable crf` goes to stderr and the exit code is non-zero.
+Emitted when the search fails to find a crf satisfying the min score & max encoded percent. Follows the failing attempt's `sample-encode-done`, which carries that attempt's crf & scores. As in human mode, `Error: Failed to find a suitable crf` goes to stderr and the exit code is non-zero.
 
 Field | Description | Type/Units
 ---|---|---
@@ -85,16 +68,16 @@ Field | Description | Type/Units
 A single `sample-encode-done`.
 
 ## `crf-search` output
-`sample-encode-done` + `crf-search-attempt` per unsuccessful attempt, ending with `crf-search-done` (exit 0) or `crf-search-error` (non-zero exit).
+A `sample-encode-done` per crf attempted, ending with `crf-search-done` (exit 0) or `crf-search-error` (non-zero exit).
 
 Guarantees:
 * Exactly one `sample-encode-done` per crf attempted.
 * The final line is a `crf-search-done` or `crf-search-error`. Other errors (e.g. invalid input) end the stream with no final json message: stderr `Error:` line & non-zero exit only.
+* A `crf-search-error` is immediately preceded by the failing attempt's `sample-encode-done`.
 
 ### Example: successful search
 ```json
 {"crf":37.5,"from_cache":false,"predicted_encode_percent":3.9154531401777755,"predicted_encode_seconds":9.0,"predicted_encode_size":19469845,"type":"sample-encode-done","vmaf":90.38392639160156}
-{"crf":37.5,"from_cache":false,"predicted_encode_percent":3.9154531401777755,"type":"crf-search-attempt","vmaf":90.38392639160156}
 {"crf":29.75,"from_cache":false,"predicted_encode_percent":13.785497397240093,"predicted_encode_seconds":13.0,"predicted_encode_size":68549279,"type":"sample-encode-done","vmaf":95.16242980957031}
 {"crf":29.75,"from_cache":false,"predicted_encode_percent":13.785497397240093,"predicted_encode_seconds":13.0,"predicted_encode_size":68549279,"type":"crf-search-done","vmaf":95.16242980957031}
 ```
@@ -102,6 +85,5 @@ Guarantees:
 ### Example: failed search
 ```json
 {"crf":18.0,"from_cache":false,"predicted_encode_percent":58.12225504159517,"predicted_encode_seconds":18.0,"predicted_encode_size":289016681,"type":"sample-encode-done","vmaf":98.99139404296875}
-{"crf":18.0,"from_cache":false,"predicted_encode_percent":58.12225504159517,"type":"crf-search-attempt","vmaf":98.99139404296875}
 {"message":"Failed to find a suitable crf","type":"crf-search-error"}
 ```

--- a/stdout-format-json.md
+++ b/stdout-format-json.md
@@ -5,7 +5,6 @@ Commands supporting `--stdout-format json` write newline-delimited JSON ([NDJSON
 Supported by: `sample-encode`, `crf-search`.
 
 Notes:
-* Key order is not significant (currently alphabetical, so `type` is typically last).
 * Later versions may add keys & message kinds, consumers should ignore unknown ones.
 * Failures print an `Error: ...` line to stderr and exit non-zero, in json mode too. The only failure also reported as json is a failed crf-search, see [`crf-search-error`](#crf-search-error).
 


### PR DESCRIPTION
Fair warning, I did my utmost to follow your recs, project norms, keep it lean, etc. but fable wrote all the code, I totally understand if you choose to close.

Implements the phase-one plan from your comment in #313 (https://github.com/alexheretic/ab-av1/issues/313#issuecomment-3828789649): NDJSON output for `crf-search`, consistent with the existing `sample-encode` json.

Message kinds, specced with examples in stdout-format-json.md:

* `sample-encode-done`: the existing sample-encode object plus `type`, `crf` & `from_cache` (additive, so non-breaking). Emitted once by `sample-encode` and once per crf attempt by `crf-search`.
* `crf-search-attempt` after each unsuccessful attempt.
* `crf-search-done` on success, `crf-search-error` on search failure.

Calls I made that you may want to override, each is a small change and I'm happy to flip any:

1. `crf-search-attempt` carries only what the human attempt line prints: `crf`, `vmaf`/`xpsnr`, `predicted_encode_percent`, `from_cache`. The full predictions are in the adjacent `sample-encode-done`, so identical field sets would mean two near-identical lines per attempt.
2. On search failure the failing attempt still emits a `crf-search-attempt` before `crf-search-error`, matching human mode which prints that attempt line.
3. `crf-search-error` is minimal (`type` + `message`) and covers only "Failed to find a suitable crf". Other errors stay stderr + non-zero exit, and `err.rs` is untouched, per your review in #336.
4. Dropped `"sample": 2` from your sketch: the message covers the whole sample-encode run, so a sample number has no referent.

Implementation notes:

* `--stdout-format` is not exposed on `auto-encode`: the shared search params moved into `SearchArgs` (flattened by both commands) and the flag lives on crf-search's own `Args` only.
* Human output is unchanged. In json mode attempt/sample data is emitted regardless of `-v`.
* Key order is serde_json's default alphabetical order, so `type` sorts last; the doc examples show real output.

Closes #313. Supersedes #336 (thanks @hashhar). Context: #334.

