### PR TITLE
docs: Fix --temp-dir default (cwd, not input dir)

### DIFF
--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -77,7 +77,7 @@ pub struct Sample {
     pub keep: bool,
 
     /// Directory to store temporary sample data in.
-    /// Defaults to using the input's directory.
+    /// Defaults to the current working directory.
     #[arg(long, env = "AB_AV1_TEMP_DIR", value_hint = ValueHint::DirPath)]
     pub temp_dir: Option<PathBuf>,
 


### PR DESCRIPTION
The `--temp-dir` doc-comment still claimed the default is "the input's directory," but since #132 (v0.7.6) an unset `--temp-dir` falls back to the current working directory (`env::current_dir()` in `temporary::process_dir`). This corrects the help text to match the actual behavior; the sibling doc-comment in `temporary.rs` already describes the cwd fallback.
