### PR TITLE
Fix sample-encode reporting success when sample creation panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add crf-search `--stdout-format json` outputting newline delimited json messages,
   see [stdout-format-json.md](stdout-format-json.md).
 * Add `type`, `crf` & `from_cache` keys to the sample-encode `--stdout-format json` output.
+* Improve error handling when temp dirs have insufficient permissions.
 
 # v0.11.4
 * Fix "sample x/n ..." log formatting.

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -14,7 +14,7 @@ use crate::{
     vmaf::{self, VmafOut},
     xpsnr::{self, XpsnrOut},
 };
-use anyhow::ensure;
+use anyhow::{Context, ensure};
 use clap::{ArgAction, Parser};
 use console::style;
 use futures_util::Stream;
@@ -201,7 +201,7 @@ pub fn run(
         let (tx, mut sample_tasks) = tokio::sync::mpsc::unbounded_channel();
         let sample_temp = temp_dir.clone();
         let sample_in = input.clone();
-        tokio::task::spawn_local(async move {
+        let sample_task = tokio::task::spawn_local(async move {
             if full_pass {
                 // Use the entire video as a single sample
                 let _ = tx.send((0, Ok((sample_in.clone(), input_len))));
@@ -435,6 +435,9 @@ pub fn run(
             results.push(result.clone());
             yield Update::SampleResult { sample: sample_n, result };
         }
+        // The channel also closes if the sample task panicked, which would otherwise
+        // leave `results` empty & be reported as a successful zero-size prediction.
+        sample_task.await.context("sample copy task")?;
 
         let output = Output {
             vmaf_score: results.mean_vmaf_score(),

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -435,8 +435,7 @@ pub fn run(
             results.push(result.clone());
             yield Update::SampleResult { sample: sample_n, result };
         }
-        // The channel also closes if the sample task panicked, which would otherwise
-        // leave `results` empty & be reported as a successful zero-size prediction.
+        // ensure sample_task completed
         sample_task.await.context("sample copy task")?;
 
         let output = Output {

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -80,7 +80,7 @@ pub fn encode_sample(
         None => input.with_extension(format!("{pre}.crf{crf_str}.{dest_ext}")),
     };
     let dest_file_name = dest_file_name.file_name().unwrap();
-    let mut dest = temporary::process_dir(temp_dir);
+    let mut dest = temporary::process_dir(temp_dir)?;
     dest.push(dest_file_name);
 
     temporary::add(&dest, TempKind::Keepable);

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -26,7 +26,7 @@ pub async fn copy(
         sample_start_s = sample_start_s.floor();
     }
 
-    let mut dest = temporary::process_dir(temp_dir);
+    let mut dest = temporary::process_dir(temp_dir)?;
     // Always using mkv for the samples works better than, e.g. using mp4 for mp4s
     // see https://github.com/alexheretic/ab-av1/issues/82#issuecomment-1337306325
     dest.push(

--- a/src/temporary.rs
+++ b/src/temporary.rs
@@ -1,4 +1,5 @@
 //! temp file logic
+use anyhow::Context;
 use std::{
     collections::HashMap,
     env, iter,
@@ -73,21 +74,23 @@ async fn clean_non_keepables() {
 /// Return a temporary directory that is distinct per process/run.
 ///
 /// Configured --temp-dir is used as a parent or, if not set, the current working dir.
-pub fn process_dir(conf_parent: Option<PathBuf>) -> PathBuf {
+pub fn process_dir(conf_parent: Option<PathBuf>) -> anyhow::Result<PathBuf> {
     static SUBDIR: LazyLock<String> = LazyLock::new(|| {
         let mut subdir = String::from(".ab-av1-");
         subdir.extend(iter::repeat_with(fastrand::alphanumeric).take(12));
         subdir
     });
 
-    let mut temp_dir =
-        conf_parent.unwrap_or_else(|| env::current_dir().expect("current working directory"));
+    let mut temp_dir = match conf_parent {
+        Some(d) => d,
+        None => env::current_dir().context("current working directory")?,
+    };
     temp_dir.push(&*SUBDIR);
 
     if !temp_dir.exists() {
         add(&temp_dir, TempKind::Keepable);
-        std::fs::create_dir_all(&temp_dir).expect("failed to create temp-dir");
+        std::fs::create_dir_all(&temp_dir).context("failed to create temp-dir")?;
     }
 
-    temp_dir
+    Ok(temp_dir)
 }


### PR DESCRIPTION
The sample copy task's `JoinHandle` is dropped, so a panic in it is caught by tokio and never observed. The channel closes and the empty `results` is aggregated into a zeroed success.

```
$ mkdir ro && chmod 555 ro
$ ab-av1 sample-encode -i vid.mkv --crf 30 --temp-dir ro --stdout-format json
thread 'main' panicked at src/temporary.rs:89:44:
failed to create temp-dir: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
{"crf":30.0,"from_cache":true,"predicted_encode_percent":100.0,"predicted_encode_seconds":0.0,"predicted_encode_size":0,"type":"sample-encode-done"}
$ echo $?
0
```

`from_cache` is true because `.all()` on an empty vec is true. The same fault on the full pass path runs on the main task and exits 101.

Awaiting the handle propagates the `JoinError` instead. Happy to make `temporary::process_dir` return `Result` if you'd prefer, though this covers any panic in the task rather than one call site.
