### PR TITLE
Fix auto-encode --keep discarding temp files on success

### DIFF
--- a/src/command/auto_encode.rs
+++ b/src/command/auto_encode.rs
@@ -80,6 +80,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
     let enc_args = search.args.clone();
     let thorough = search.thorough;
     let verbose = search.verbose;
+    let keep = search.sample.keep;
 
     let mut crf_search = pin!(crf_search::run(search, input_probe.clone()));
     let mut best = None;
@@ -170,7 +171,7 @@ pub async fn auto_encode(Args { mut search, encode }: Args) -> anyhow::Result<()
         style(best.enc.single_score()).green(),
         style(format!("{:.0}%", best.enc.encode_percent)).green(),
     ));
-    temporary::clean_all().await;
+    temporary::clean(keep).await;
 
     let bar = ProgressBar::new(12).with_style(
         ProgressStyle::default_bar()


### PR DESCRIPTION
`auto-encode --keep` discards the search temporaries on success: `clean_all()` between the search and encode phases empties the map before `clean(keep)` in main runs. `crf-search` never calls `clean_all()`, so `crf-search --keep` keeps them, as do interrupted or failed auto-encode runs.

#21 added the call in 2022, #166 added `--keep` for auto-encode two years later without touching it. If a completed auto-encode is meant to clean up regardless, the help text shouldn't promise otherwise.

`temporary::clean(keep)` instead. `clean(false)` is `clean_all()`, so nothing changes without the flag.
