### PR TITLE
libx265: Default `--enc tag:v=hvc1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (0.11.6)
+* libx265: Default `--enc tag:v=hvc1` for better compatibilty. The ffmpeg default can be explicitly set with `--enc tag:v=hev1`.
+
 # v0.11.5
 * Encode to a temporary file before renaming to the final destination to ensure atomicity and prevent partially encoded files.
 * Fix auto-encode `--keep` function.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -147,9 +147,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -179,9 +179,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -195,9 +195,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.8"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "fs2"
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -654,9 +654,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1009,18 +1009,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1152,9 +1152,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1175,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -81,7 +81,7 @@ pub struct Sample {
     #[arg(long, env = "AB_AV1_TEMP_DIR", value_hint = ValueHint::DirPath)]
     pub temp_dir: Option<PathBuf>,
 
-    /// Extension preference for encoded samples (ffmpeg encoder only).
+    /// Extension preference for encoded samples.
     #[arg(skip)]
     pub extension: Option<Arc<str>>,
 }

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -186,6 +186,7 @@ impl Encode {
         &self,
         crf: f32,
         probe: &Ffprobe,
+        output_ext: &str,
     ) -> anyhow::Result<FfmpegEncodeArgs<'_>> {
         let vcodec = &self.encoder.0;
         let svtav1 = vcodec.as_ref() == "libsvtav1";
@@ -245,7 +246,7 @@ impl Encode {
             args.push(keyint.to_string().into());
         }
 
-        for (name, val) in self.encoder.default_ffmpeg_args() {
+        for (name, val) in self.encoder.default_ffmpeg_args(output_ext) {
             if !args.iter().any(|arg| &**arg == name) {
                 args.push(name.to_string().into());
                 args.push(val.to_string().into());
@@ -415,11 +416,15 @@ impl Encoder {
         }
     }
 
-    /// Additional encoder specific ffmpeg arg defaults.
-    fn default_ffmpeg_args(&self) -> &[(&'static str, &'static str)] {
+    /// Additional encoder specific ffmpeg output arg defaults.
+    fn default_ffmpeg_args(&self, ext: &str) -> &[(&'static str, &'static str)] {
         match self.as_str() {
             // add `-b:v 0` for aom & vp9 to use "constant quality" mode
             "libaom-av1" | "libvpx-vp9" => &[("-b:v", "0")],
+            // apple compat for hevc
+            "libx265" if ext.eq_ignore_ascii_case("mp4") || ext.eq_ignore_ascii_case("mov") => {
+                &[("-tag:v", "hvc1")]
+            }
             // enable lookahead mode for qsv encoders
             "av1_qsv" | "hevc_qsv" | "h264_qsv" => &[
                 ("-look_ahead", "1"),
@@ -629,7 +634,9 @@ fn svtav1_to_ffmpeg_args_default_over_3m() {
         output_args,
         input_args,
         video_only,
-    } = enc.to_ffmpeg_args(32.0, &probe).expect("to_ffmpeg_args");
+    } = enc
+        .to_ffmpeg_args(32.0, &probe, "mkv")
+        .expect("to_ffmpeg_args");
 
     assert_eq!(&*vcodec, "libsvtav1");
     assert_eq!(input, enc.input);
@@ -692,7 +699,9 @@ fn svtav1_to_ffmpeg_args_default_under_3m() {
         output_args,
         input_args,
         video_only,
-    } = enc.to_ffmpeg_args(32.0, &probe).expect("to_ffmpeg_args");
+    } = enc
+        .to_ffmpeg_args(32.0, &probe, "mkv")
+        .expect("to_ffmpeg_args");
 
     assert_eq!(&*vcodec, "libsvtav1");
     assert_eq!(input, enc.input);
@@ -716,4 +725,100 @@ fn svtav1_to_ffmpeg_args_default_under_3m() {
         .as_str();
     assert_eq!(svtargs, "scd=0:crf=32");
     assert!(input_args.is_empty());
+}
+
+#[test]
+fn libx265_default_hvc1_mp4_mov() {
+    let enc = Encode {
+        encoder: Encoder("libx265".into()),
+        input: "vid.mp4".into(),
+        vfilter: None,
+        preset: None,
+        pix_format: None,
+        keyint: None,
+        scd: None,
+        svt_args: <_>::default(),
+        enc_args: <_>::default(),
+        enc_input_args: <_>::default(),
+    };
+
+    let probe = Ffprobe {
+        duration: Ok(Duration::from_secs(300)),
+        has_audio: true,
+        max_audio_channels: None,
+        fps: Ok(30.0),
+        resolution: Some((1280, 720)),
+        is_image: false,
+        pix_fmt: None,
+    };
+
+    let FfmpegEncodeArgs { output_args, .. } = enc
+        .to_ffmpeg_args(32.0, &probe, "mp4")
+        .expect("to_ffmpeg_args");
+    assert!(
+        output_args
+            .windows(2)
+            .any(|w| w[0].as_str() == "-tag:v" && w[1].as_str() == "hvc1"),
+        "mp4: expected -tag:v hvc1 in {output_args:?}"
+    );
+
+    let FfmpegEncodeArgs { output_args, .. } = enc
+        .to_ffmpeg_args(32.0, &probe, "mov")
+        .expect("to_ffmpeg_args");
+    assert!(
+        output_args
+            .windows(2)
+            .any(|w| w[0].as_str() == "-tag:v" && w[1].as_str() == "hvc1"),
+        "mov: expected -tag:v hvc1 in {output_args:?}"
+    );
+
+    let FfmpegEncodeArgs { output_args, .. } = enc
+        .to_ffmpeg_args(32.0, &probe, "mkv")
+        .expect("to_ffmpeg_args");
+    assert!(
+        !output_args.windows(2).any(|w| w[0].as_str() == "-tag:v"),
+        "mkv: expected no -tag:v in {output_args:?}"
+    );
+}
+
+#[test]
+fn libx265_explicit_tagv_mp4() {
+    let enc = Encode {
+        encoder: Encoder("libx265".into()),
+        input: "vid.mp4".into(),
+        vfilter: None,
+        preset: None,
+        pix_format: None,
+        keyint: None,
+        scd: None,
+        svt_args: <_>::default(),
+        enc_args: vec!["-tag:v=hev1".into()],
+        enc_input_args: <_>::default(),
+    };
+
+    let probe = Ffprobe {
+        duration: Ok(Duration::from_secs(300)),
+        has_audio: true,
+        max_audio_channels: None,
+        fps: Ok(30.0),
+        resolution: Some((1280, 720)),
+        is_image: false,
+        pix_fmt: None,
+    };
+
+    let FfmpegEncodeArgs { output_args, .. } = enc
+        .to_ffmpeg_args(32.0, &probe, "mp4")
+        .expect("to_ffmpeg_args");
+    assert!(
+        output_args
+            .windows(2)
+            .any(|w| w[0].as_str() == "-tag:v" && w[1].as_str() == "hev1"),
+        "mp4: expected -tag:v hev1 in {output_args:?}"
+    );
+    assert!(
+        !output_args
+            .windows(2)
+            .any(|w| w[0].as_str() == "-tag:v" && w[1].as_str() == "hcv1"),
+        "mp4: unexpected -tag:v hcv1 in {output_args:?}"
+    );
 }

--- a/src/command/args/encode.rs
+++ b/src/command/args/encode.rs
@@ -729,7 +729,7 @@ fn svtav1_to_ffmpeg_args_default_under_3m() {
 
 #[test]
 fn libx265_default_hvc1_mp4_mov() {
-    let enc = Encode {
+    let mut enc = Encode {
         encoder: Encoder("libx265".into()),
         input: "vid.mp4".into(),
         vfilter: None,
@@ -779,32 +779,9 @@ fn libx265_default_hvc1_mp4_mov() {
         !output_args.windows(2).any(|w| w[0].as_str() == "-tag:v"),
         "mkv: expected no -tag:v in {output_args:?}"
     );
-}
 
-#[test]
-fn libx265_explicit_tagv_mp4() {
-    let enc = Encode {
-        encoder: Encoder("libx265".into()),
-        input: "vid.mp4".into(),
-        vfilter: None,
-        preset: None,
-        pix_format: None,
-        keyint: None,
-        scd: None,
-        svt_args: <_>::default(),
-        enc_args: vec!["-tag:v=hev1".into()],
-        enc_input_args: <_>::default(),
-    };
-
-    let probe = Ffprobe {
-        duration: Ok(Duration::from_secs(300)),
-        has_audio: true,
-        max_audio_channels: None,
-        fps: Ok(30.0),
-        resolution: Some((1280, 720)),
-        is_image: false,
-        pix_fmt: None,
-    };
+    // don't when explicitly set by user
+    enc.enc_args.push("-tag:v=hev1".into());
 
     let FfmpegEncodeArgs { output_args, .. } = enc
         .to_ffmpeg_args(32.0, &probe, "mp4")

--- a/src/command/encode.rs
+++ b/src/command/encode.rs
@@ -84,7 +84,14 @@ pub async fn run(
     }
     bar.set_message("encoding, ");
 
-    let mut enc_args = args.to_ffmpeg_args(crf, &probe)?;
+    let mut enc_args = args.to_ffmpeg_args(
+        crf,
+        &probe,
+        output
+            .extension()
+            .and_then(|e| e.to_str())
+            .context("no output extension?")?,
+    )?;
     enc_args.video_only = video_only;
     let has_audio = probe.has_audio;
     if let Ok(d) = &probe.duration {

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -160,7 +160,8 @@ pub fn run(
         let input_pix_fmt = input_probe.pixel_format();
         let input_is_image = input_probe.is_image;
         let input_len = fs::metadata(&*input).await?.len();
-        let mut enc_args = args.to_ffmpeg_args(crf, &input_probe)?;
+        let sample_out_ext = sample_args.extension.as_deref().unwrap_or("mkv");
+        let mut enc_args = args.to_ffmpeg_args(crf, &input_probe, sample_out_ext)?;
         // ignore user -fps_mode for sample encoding, as we always use passthrough
         remove_arg(&mut enc_args.output_args, "-fps_mode");
         remove_arg(&mut enc_args.output_args, "-vsync");
@@ -170,11 +171,6 @@ pub fn run(
         let samples = sample_args.sample_count(duration).max(1);
         let keep = sample_args.keep;
         let temp_dir = sample_args.temp_dir;
-        // let scoring = ScoringInfo {
-        //     args: &score,
-        //     vmaf: &vmaf,
-        //     xpsnr: &xpsnr,
-        // };
 
         let (samples, sample_duration, full_pass) = {
             if input_is_image {
@@ -271,7 +267,7 @@ pub fn run(
                             ..enc_args.clone()
                         },
                         temp_dir.clone(),
-                        sample_args.extension.as_deref().unwrap_or("mkv"),
+                        sample_out_ext,
                     )?;
                     while let Some(enc_progress) = output.next().await {
                         if let FfmpegOut::Progress { time, fps, .. } = enc_progress? {


### PR DESCRIPTION
libx265: Default `--enc tag:v=hvc1` for better compatibilty. The ffmpeg default can be explicitly set with `--enc tag:v=hev1`.

Resolves #375 