### PR TITLE
Use ffmpeg to find svt-av1 version for caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (0.11.7)
+* Use ffmpeg (instead of SvtAv1EncApp) to find svt-av1 version for caching validity logic.
+
 # v0.11.6
 * libx265: Default `--enc tag:v=hvc1` for better compatibilty. The ffmpeg default can be explicitly set with `--enc tag:v=hev1`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "blake3",
+ "bstr",
  "clap",
  "clap-verbosity-flag",
  "clap_complete",
@@ -157,6 +158,17 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 anyhow = "1.0.53"
 async-stream = "0.3.5"
 blake3 = "1.3.3"
+bstr = "1.13.1"
 clap = { version = "4", features = ["derive", "env", "wrap_help"] }
 clap-verbosity-flag = "3.0.2"
 clap_complete = "4.4.10"

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -6,11 +6,13 @@ use crate::{
     temporary::{self, TempKind},
 };
 use anyhow::Context;
+use bstr::ByteSlice;
 use log::debug;
 use std::{
     collections::HashSet,
     fmt::Write,
     hash::{Hash, Hasher},
+    io::Read,
     path::{Path, PathBuf},
     process::Stdio,
     sync::{Arc, LazyLock},
@@ -33,11 +35,9 @@ pub struct FfmpegEncodeArgs<'a> {
 
 impl FfmpegEncodeArgs<'_> {
     pub fn sample_encode_hash(&self, state: &mut impl Hasher) {
-        static SVT_AV1_V: LazyLock<Vec<u8>> = LazyLock::new(|| {
-            std::process::Command::new("SvtAv1EncApp")
-                .arg("--version")
-                .output()
-                .map(|o| o.stdout)
+        static SVT_AV1_V: LazyLock<String> = LazyLock::new(|| {
+            ffmpeg_svtav1_version()
+                .inspect_err(|e| debug!("read_ffmpeg_svtav1_version: {e}"))
                 .unwrap_or_default()
         });
 
@@ -257,4 +257,65 @@ pub fn remove_arg(args: &mut Vec<Arc<String>>, arg: &'static str) {
             true
         }
     });
+}
+
+fn ffmpeg_svtav1_version() -> anyhow::Result<String> {
+    let mut ffmpeg = std::process::Command::new("ffmpeg")
+        .args([
+            "-hide_banner",
+            "-loglevel",
+            "info",
+            "-f",
+            "lavfi",
+            "-i",
+            "color",
+            "-frames:v",
+            "1",
+            "-c:v",
+            "libsvtav1",
+            "-f",
+            "null",
+            "-",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    // buffer at least 2x the size of the expected prefix + version
+    // as we'll lose the first half once we start running out of space
+    // Example: "SVT-AV1 Encoder Lib v123.456.678"
+    const BUF_QUARTER_LEN: usize = 64;
+
+    let mut buf = [0; 4 * BUF_QUARTER_LEN];
+    let mut read_up_to = 0;
+    let mut stderr = ffmpeg.stderr.take().context("stderr")?;
+
+    std::thread::spawn(move || _ = ffmpeg.wait());
+
+    loop {
+        let n = stderr.read(&mut buf[read_up_to..])?;
+        anyhow::ensure!(n != 0, "EOF: No version string found");
+
+        read_up_to += n;
+
+        if let Some(idx) = buf[..read_up_to].find_iter("SVT-AV1 Encoder Lib v").next()
+                        && let Some(last_byte) = buf[..read_up_to].last()
+                        // the last byte should be past of the version bytes
+                        && !matches!(*last_byte, b'0'..=b'9' | b'.' | b'v')
+        {
+            let ver: Vec<_> = buf[idx + "SVT-AV1 Encoder Lib v".len()..read_up_to]
+                .iter()
+                .copied()
+                .take_while(|b| matches!(b, b'0'..=b'9' | b'.'))
+                .collect();
+
+            return Ok(String::try_from(ver)?);
+        }
+
+        if read_up_to > 3 * BUF_QUARTER_LEN {
+            buf.rotate_left(2 * BUF_QUARTER_LEN);
+            read_up_to -= 2 * BUF_QUARTER_LEN;
+        }
+    }
 }


### PR DESCRIPTION
Read and return as soon as stderr prints the version to avoid waiting ~500ms ffmpeg can take to exit. I measure this as taking **~40ms** which is acceptable.

Resolves #350