### PR TITLE
Predict encode size from input video stream size

### DIFF
--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -434,6 +434,12 @@ pub fn run(
         // ensure sample_task completed
         sample_task.await.context("sample copy task")?;
 
+        let estimate_by_vstream = if full_pass {
+            results[0].encoded_size
+        } else {
+            estimate_encode_size_by_vstream_percent(&results, &input, duration, sample_duration, temp_dir.as_deref()).await
+        };
+
         let output = Output {
             vmaf_score: results.mean_vmaf_score(),
             xpsnr_score: results.mean_xpsnr_score(),
@@ -441,7 +447,8 @@ pub fn run(
             // than the duration estimation it may turn out to be more accurate.
             predicted_encode_size: results
                 .estimate_encode_size_by_duration(duration, full_pass)
-                .min(estimate_encode_size_by_file_percent(&results, &input, full_pass).await?),
+                .min(estimate_encode_size_by_file_percent(&results, &input, full_pass).await?)
+                .min(estimate_by_vstream),
             encode_percent: results.encoded_percent_size(),
             predicted_encode_time: results.estimate_encode_time(duration, full_pass),
             from_cache: results.iter().all(|r| r.from_cache),
@@ -687,6 +694,53 @@ async fn estimate_encode_size_by_file_percent(
     let encode_proportion = results.encoded_percent_size() / 100.0;
 
     Ok((fs::metadata(input).await?.len() as f64 * encode_proportion).round() as _)
+}
+
+/// Return estimated encoded **video stream** size by applying the sample percentage
+/// change to the input's video stream size.
+///
+/// The video stream size is approximated by sampling the non-video (audio + subtitle)
+/// streams of the input with stream-copy, extrapolating to the full duration, and
+/// subtracting that from the whole input file size.
+async fn estimate_encode_size_by_vstream_percent(
+    results: &Vec<EncodeResult>,
+    input: &Path,
+    duration: Duration,
+    sample_duration: Duration,
+    temp_dir: Option<&Path>,
+) -> u64 {
+    if results.is_empty() {
+        return 0;
+    }
+    if results.len() == 1 {
+        return results[0].encoded_size;
+    }
+    let encode_proportion = results.encoded_percent_size() / 100.0;
+
+    // sample start of the first sample, mirroring `sample()`
+    let sample_start =
+        duration.saturating_sub(sample_duration * results.len() as _) / (results.len() as u32 + 1);
+    let non_video_sample_size = sample::non_video_size(
+        input,
+        sample_start,
+        sample_duration,
+        temp_dir.map(Path::to_path_buf),
+    )
+    .await
+    .unwrap_or(0);
+    if non_video_sample_size == 0 {
+        return 0;
+    }
+    let non_video_size = (non_video_sample_size as f64 * duration.as_secs_f64()
+        / sample_duration.as_secs_f64())
+    .round() as u64;
+    let input_vstream_size = fs::metadata(input)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0)
+        .saturating_sub(non_video_size);
+
+    (input_vstream_size as f64 * encode_proportion).round() as _
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -11,7 +11,56 @@ use std::{
 };
 use tokio::process::Command;
 
-/// Create a sample from `sample_start` + `frames`.
+/// Create a sample of the non-video (audio + subtitle) streams from `sample_start`
+/// for `sample_duration`, returning its file size.
+///
+/// `-c copy` makes this cheap. The size is used to approximate the input's non-video
+/// stream size, so the predicted encode size can be based on the video stream size
+/// rather than the whole file size.
+pub async fn non_video_size(
+    input: &Path,
+    sample_start: Duration,
+    sample_duration: Duration,
+    temp_dir: Option<PathBuf>,
+) -> anyhow::Result<u64> {
+    let mut sample_start_s = sample_start.as_secs_f32();
+    if sample_duration >= Duration::from_secs(2) {
+        sample_start_s = sample_start_s.floor();
+    }
+
+    let mut dest = temporary::process_dir(temp_dir)?;
+    dest.push(
+        input
+            .with_extension(format!(
+                "non-video-sample{sample_start_s}+{}s.mkv",
+                sample_duration.as_secs_f32()
+            ))
+            .file_name()
+            .unwrap(),
+    );
+    temporary::add(&dest, TempKind::Keepable);
+
+    let out = Command::new("ffmpeg")
+        .arg("-y")
+        .arg2("-ss", sample_start_s)
+        .arg2("-t", sample_duration.as_secs_f32())
+        .arg2("-i", input)
+        .arg2("-map", "0:a?")
+        .arg2("-map", "0:s?")
+        .arg2("-c", "copy")
+        .arg(&dest)
+        .stdin(Stdio::null())
+        .output()
+        .await
+        .context("ffmpeg non-video copy")?;
+
+    ensure_success("ffmpeg non-video copy", &out)?;
+    let size = tokio::fs::metadata(&dest).await?.len();
+    let _ = tokio::fs::remove_file(&dest).await;
+    Ok(size)
+}
+
+/// Copy a sample from `sample_start` + `frames`.
 ///
 /// Fast as this uses `-c:v copy`.
 pub async fn copy(


### PR DESCRIPTION
Fixes #91

Improve the predicted encode size by basing it on the input's video stream size instead of only the whole file size.

The current prediction takes the minimum of:
- `sample encode size * input/sample duration`
- `input file size * encoded %`

When the input carries large audio or subtitle tracks, `input file size * encoded %` over-estimates, and the duration method is the better one of the two — but it can still be off because it multiplies the sample *file* size rather than only the video part of it.

This PR adds a third candidate: **input video stream size * encoded %**. The input video stream size is approximated cheaply by copying a short sample of just the audio + subtitle streams (`-map 0:a? -map 0:s? -c copy`), extrapolating that sample to the full duration, and subtracting it from the input file size. It's one extra stream-copy per run, no re-encode.

Result order stays: min(duration based, file % based, video stream % based). For files with little or no non-video data the new candidate converges to the file-% value so it doesn't change current behaviour there.

Verified with `cargo test`, `cargo fmt --check` and `cargo clippy`.
