### PR TITLE
Seed crf search from cached sample-encode results

### DIFF
--- a/src/command/crf_search.rs
+++ b/src/command/crf_search.rs
@@ -10,6 +10,7 @@ use crate::{
     console_ext::style,
     ffprobe::{self, Ffprobe},
     float::TerseF32,
+    sample,
 };
 use anyhow::Context;
 use clap::{ArgAction, Parser};
@@ -300,6 +301,30 @@ pub fn run(
         assert!(min_q < max_q);
         let mut q = (min_q + max_q) / 2;
 
+        // Seed the initial search point from previously cached sample-encode results for
+        // this input & encoder, if any exist. This lets a re-run (e.g. with adjusted or
+        // default crf bounds) start from where a prior search already landed instead of
+        // always from the midpoint of the range. Best-effort: any probe failure just
+        // leaves the search starting from the midpoint.
+        if let Ok(Some(seeded_q)) = seed_q_from_cache(
+            cache,
+            &args,
+            &input_probe,
+            min_crf,
+            max_crf,
+            crf_increment,
+            &q_conv,
+            &sample,
+            min_score,
+            &score,
+            &vmaf,
+            &xpsnr,
+        )
+        .await
+        {
+            q = seeded_q;
+        }
+
         let mut args = sample_encode::Args {
             args: args.clone(),
             crf: 0.0,
@@ -409,6 +434,100 @@ pub fn run(
         }
         unreachable!();
     }
+}
+
+/// Probe the sample-encode cache for prior results at the search's first sample position,
+/// returning the `q` of the cached result closest below (better than) the target score.
+///
+/// Returns `None` when there's nothing useful cached, or when the probe can't run
+/// (e.g. no cached sample, invalid duration). Best-effort: callers fall back to the
+/// default midpoint start.
+#[allow(clippy::too_many_arguments)]
+async fn seed_q_from_cache(
+    cache: bool,
+    args: &args::Encode,
+    input_probe: &Ffprobe,
+    min_crf: f32,
+    max_crf: f32,
+    crf_increment: f32,
+    q_conv: &QualityConverter,
+    sample: &args::Sample,
+    min_score: f32,
+    score: &args::ScoreArgs,
+    vmaf: &args::Vmaf,
+    xpsnr: &args::Xpsnr,
+) -> anyhow::Result<Option<i64>> {
+    if !cache {
+        return Ok(None);
+    }
+
+    let input_len = tokio::fs::metadata(&*args.input).await?.len();
+    let duration = input_probe.duration.clone()?;
+    let input_fps = input_probe.fps.clone().unwrap_or_default();
+    let is_image = input_probe.is_image;
+    let samples = sample.sample_count(duration).max(1);
+    let full_pass = is_image
+        || sample.sample_duration.is_zero()
+        || sample.sample_duration * samples as _ >= duration.mul_f64(0.85);
+    if full_pass {
+        return Ok(None);
+    }
+
+    // Compute the first sample file name, mirroring sample_encode::sample() idx 0 &
+    // sample::copy naming, so the same cache keys are probed.
+    let sample_duration = if input_fps > 0.0 {
+        sample
+            .sample_duration
+            .max(Duration::from_secs_f64(1.0 / input_fps))
+    } else {
+        sample.sample_duration
+    };
+    let sample_start =
+        duration.saturating_sub(sample_duration * samples as _) / (samples as u32 + 1);
+    let sample_frames = ((sample_duration.as_secs_f64() * input_fps).round() as u32).max(1);
+    let sample_name = std::path::Path::new(&args.input).with_file_name(sample::sample_file_name(
+        &args.input,
+        sample_start,
+        sample_duration >= Duration::from_secs(2),
+        sample_frames,
+    ));
+
+    // Probe a modest grid of crf values across the search range.
+    let step = ((max_crf - min_crf) / 20.0).max(crf_increment);
+    let mut crf_values = Vec::new();
+    let mut crf = min_crf;
+    while crf <= max_crf {
+        crf_values.push((crf, q_conv.q(crf)));
+        crf += step;
+    }
+    crf_values.push((max_crf, q_conv.q(max_crf)));
+
+    // The crf set here is a placeholder; cached_crfs overrides it per candidate.
+    let enc_args = args.to_ffmpeg_args(min_crf, input_probe, "mkv")?;
+    let cached = sample_encode::cache::cached_crfs(
+        true,
+        &sample_name,
+        duration,
+        args.input.extension(),
+        input_len,
+        false,
+        &enc_args,
+        (score, vmaf, xpsnr),
+        &crf_values,
+    )
+    .await;
+
+    // Choose the cached result closest below (higher quality than) the target score.
+    Ok(cached
+        .iter()
+        .filter(|(_, _, r)| r.vmaf_score.or(r.xpsnr_score).unwrap_or_default() < min_score)
+        .max_by(|a, b| {
+            a.2.vmaf_score
+                .or(a.2.xpsnr_score)
+                .unwrap_or_default()
+                .total_cmp(&b.2.vmaf_score.or(b.2.xpsnr_score).unwrap_or_default())
+        })
+        .map(|(_, q, _)| *q))
 }
 
 #[derive(Debug, Clone)]

--- a/src/command/sample_encode.rs
+++ b/src/command/sample_encode.rs
@@ -1,4 +1,4 @@
-mod cache;
+pub(crate) mod cache;
 
 use crate::{
     command::{

--- a/src/command/sample_encode/cache.rs
+++ b/src/command/sample_encode/cache.rs
@@ -24,22 +24,15 @@ pub async fn cached_encode(
         return (None, None);
     }
 
-    let hash = hash_encode(
-        // hashing the sample file name (which includes input name, frames & start)
-        // + input duration, extension & size should be reasonably unique for an input.
-        // and is much faster than hashing the entire file.
-        (
-            sample.file_name(),
-            input_duration,
-            input_extension,
-            input_size,
-            full_pass,
-        ),
+    let key = encode_key(
+        sample,
+        input_duration,
+        input_extension,
+        input_size,
+        full_pass,
         enc_args,
         scoring,
     );
-
-    let key = Key(hash);
 
     let cached = tokio::task::spawn_blocking::<_, anyhow::Result<_>>(move || {
         let db = open_db()?;
@@ -61,6 +54,66 @@ pub async fn cached_encode(
         Err(err) => {
             eprintln!("cache error: {err}");
             (None, None)
+        }
+    }
+}
+
+/// Look up previously cached sample-encode results for a set of crf values, sharing the
+/// same input sample & encoder args. Returns the (crf, result) pairs that are cached.
+///
+/// Used to seed a new crf-search from the results of a prior run that used the same
+/// input & encoder, instead of always starting from the midpoint of the crf range.
+#[allow(clippy::too_many_arguments)]
+pub async fn cached_crfs(
+    cache: bool,
+    sample: &Path,
+    input_duration: Duration,
+    input_extension: Option<&OsStr>,
+    input_size: u64,
+    full_pass: bool,
+    enc_args: &FfmpegEncodeArgs<'_>,
+    scoring: impl Hash + Clone,
+    crf_values: &[(f32, i64)], // (crf, q)
+) -> Vec<(f32, i64, super::EncodeResult)> {
+    if !cache {
+        return Vec::new();
+    }
+
+    let mut keys = Vec::with_capacity(crf_values.len());
+    for (crf, q) in crf_values {
+        let mut args = enc_args.clone();
+        args.crf = *crf;
+        let key = encode_key(
+            sample,
+            input_duration,
+            input_extension,
+            input_size,
+            full_pass,
+            &args,
+            scoring.clone(),
+        );
+        keys.push((*crf, *q, key));
+    }
+
+    match tokio::task::spawn_blocking(move || {
+        let db = open_db()?;
+        let mut results = Vec::new();
+        for (crf, q, key) in &keys {
+            if let Some(data) = db.get(key.0.to_hex().as_bytes())?
+                && let Ok(mut result) = serde_json::from_slice::<super::EncodeResult>(&data)
+            {
+                result.from_cache = true;
+                results.push((*crf, *q, result));
+            }
+        }
+        Ok::<_, anyhow::Error>(results)
+    })
+    .await
+    {
+        Ok(Ok(results)) => results,
+        _ => {
+            eprintln!("cache error reading cached crf results");
+            Vec::new()
         }
     }
 }
@@ -99,6 +152,31 @@ fn open_db() -> sled::Result<sled::Db> {
 
 #[derive(Debug, Clone, Copy)]
 pub struct Key(blake3::Hash);
+
+fn encode_key(
+    sample: &Path,
+    input_duration: Duration,
+    input_extension: Option<&OsStr>,
+    input_size: u64,
+    full_pass: bool,
+    enc_args: &FfmpegEncodeArgs<'_>,
+    scoring: impl Hash,
+) -> Key {
+    Key(hash_encode(
+        // hashing the sample file name (which includes input name, frames & start)
+        // + input duration, extension & size should be reasonably unique for an input.
+        // and is much faster than hashing the entire file.
+        (
+            sample.file_name(),
+            input_duration,
+            input_extension,
+            input_size,
+            full_pass,
+        ),
+        enc_args,
+        scoring,
+    ))
+}
 
 fn hash_encode(
     input_info: impl Hash,

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -11,6 +11,28 @@ use std::{
 };
 use tokio::process::Command;
 
+/// The file name used for a copy sample of `input` at `sample_start` with `frames`.
+///
+/// Mirrors the destination file name used by [`copy`], so the sample-encode cache key
+/// derived from the file name can be computed without creating the file.
+pub fn sample_file_name(
+    input: &Path,
+    sample_start: Duration,
+    floor_to_sec: bool,
+    frames: u32,
+) -> String {
+    let mut sample_start_s = sample_start.as_secs_f32();
+    if floor_to_sec {
+        sample_start_s = sample_start_s.floor();
+    }
+    input
+        .with_extension(format!("sample{sample_start_s}+{frames}f.mkv"))
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned()
+}
+
 /// Create a sample from `sample_start` + `frames`.
 ///
 /// Fast as this uses `-c:v copy`.
@@ -29,12 +51,7 @@ pub async fn copy(
     let mut dest = temporary::process_dir(temp_dir)?;
     // Always using mkv for the samples works better than, e.g. using mp4 for mp4s
     // see https://github.com/alexheretic/ab-av1/issues/82#issuecomment-1337306325
-    dest.push(
-        input
-            .with_extension(format!("sample{sample_start_s}+{frames}f.mkv"))
-            .file_name()
-            .unwrap(),
-    );
+    dest.push(sample_file_name(input, sample_start, floor_to_sec, frames));
     if dest.exists() {
         return Ok(dest);
     }
@@ -79,4 +96,25 @@ pub async fn copy(
 
     ensure_success("ffmpeg copy", &out)?;
     Ok(dest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sample_file_name_uses_mkv_and_floor_when_floor_to_sec() {
+        let input = PathBuf::from("/tmp/movie.mkv");
+        let start = Duration::from_millis(15200);
+        let name = sample_file_name(&input, start, true, 120);
+        assert_eq!(name, "movie.sample15+120f.mkv");
+    }
+
+    #[test]
+    fn sample_file_name_keeps_fraction_when_not_floored() {
+        let input = PathBuf::from("/tmp/movie.mkv");
+        let start = Duration::from_millis(15200);
+        let name = sample_file_name(&input, start, false, 120);
+        assert_eq!(name, "movie.sample15.2+120f.mkv");
+    }
 }


### PR DESCRIPTION
Fixes #151

The crf search always started at the midpoint of the min/max range, and the per-crf results already in the sample-encode cache were only picked up if a new search point happened to land on an identical sample+args hash. Re-running with wider `--max-crf` (or just re-running) therefore never benefited from a previous search on the same input+encoder.

This makes the search ask the existing cache which crfs it already has for this input+sample at startup, and start from the cached result closest below the target score instead of the midpoint.

Implementation notes:
- `cache::cached_crfs` looks up a grid of candidate crf values at the first sample position, reusing the exact cache key derivation from `cached_encode` so only reads happen — nothing new is persisted and the storage model is unchanged.
- The first sample file name is shared via `sample::sample_file_name`, used both by `sample::copy` and the probe, so the probed keys always match the ones the search produces (it was previously embedded inline).
- If nothing is cached (or the probe can't run, e.g. image inputs / full-pass), the search falls back to the midpoint as before — this is strictly an optimization.

Verified with `cargo test` (40 passing incl. 2 new), `cargo fmt --check` and `cargo clippy`.
